### PR TITLE
hmc-351: add dockerfile for local dev

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,30 @@
+# Variables
+DOCKER_IMAGE = project-2a-docs
+DOCKERFILE_PATH = docker/Dockerfile
+DOCKER_TAG = latest
+CONTAINER_NAME = project-2a-docs-container
+PORT = 8000
+
+# Default target
+.PHONY: all
+all: build run
+
+# Build the Docker image
+.PHONY: build
+build:
+	docker build -t $(DOCKER_IMAGE):$(DOCKER_TAG) -f $(DOCKERFILE_PATH) .
+
+# Run the Docker container
+.PHONY: run
+run:
+	docker run --rm -p $(PORT):8000 -v $(shell pwd):/docs --name $(CONTAINER_NAME) $(DOCKER_IMAGE):$(DOCKER_TAG)
+
+# Stop the container if it's running
+.PHONY: stop
+stop:
+	docker stop $(CONTAINER_NAME) || true
+
+# Clean up Docker images and containers
+.PHONY: clean
+clean:
+	docker rmi $(DOCKER_IMAGE):$(DOCKER_TAG) || true

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,35 @@
+# Copyright 2024
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Use an official Python image as the base image
+FROM python:3.8-slim
+
+# Set a working directory inside the container
+WORKDIR /docs
+
+# Copy only the requirements file to avoid re-installing dependencies if code changes
+COPY requirements.txt .
+
+# Install dependencies using pip
+# Here, we're installing MkDocs and the Material theme
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy the rest of the documentation files into the working directory
+COPY . .
+
+# Expose port 8000 to access the MkDocs server from outside the container
+EXPOSE 8000
+
+# Command to run the MkDocs development server on port 8000
+CMD ["mkdocs", "serve", "--dev-addr=0.0.0.0:8000"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,105 @@
+# Local Docker Setup for Project Documentation
+
+This folder contains the necessary files to build and run a `Docker` container for serving the documentation locally using **MkDocs** and **Material for MkDocs**.
+
+## Prerequisites
+Before using the `Makefile`, ensure the following are installed:
+
+- Docker
+- Make
+
+---
+
+## Usage
+This project comes with a Makefile to automate Docker-related tasks, such as building images, running containers, and cleaning up resources.
+
+## Makefile Commands
+
+Below are the available commands in the Makefile:
+
+### 1. Build the Docker image
+To build the Docker image defined in the `docker/Dockerfile`, run:
+
+```bash
+make build
+```
+This command will:
+
+Build a Docker image with the name specified in the DOCKER_IMAGE variable (project-2a-docs).
+
+Tag the image with the version specified in DOCKER_TAG (default is latest).
+
+Use the Dockerfile located at the DOCKERFILE_PATH (docker/Dockerfile).
+
+### 2. Run the Docker container
+To run the Docker container after building the image, run:
+
+```bash
+make run
+```
+This command will:
+
+Run the container with the name project-2a-docs-container.
+
+Map port 8000 from the container to the host (or any other port you define in the PORT variable).
+
+Automatically remove the container when it stops (--rm).
+Once running, the application will be accessible at http://localhost:8000.
+
+### 3. Stop the Docker container
+If the container is running, you can stop it with:
+
+```bash
+make stop
+```
+This will stop the container named project-2a-docs-container. If the container is not running, this command will not cause any errors.
+
+### 3. Clean up Docker images
+To remove the Docker image created by the build command, run:
+
+```bash
+make clean
+```
+This will:
+
+Remove the Docker image specified by DOCKER_IMAGE and DOCKER_TAG.
+
+If the image is not found, the command will fail silently due to || true in the command.
+
+### 4. Full Workflow Example
+Build the Docker image:
+
+```bash
+make build
+```
+
+Run the Docker container:
+
+```bash
+make run
+```
+
+Stop the Docker container:
+
+```bash
+make stop
+```
+
+Clean up the Docker image:
+
+```bash
+make clean
+```
+
+### 5. Customizing the Makefile
+The following variables are defined in the Makefile, and you can customize them as needed:
+
+1. `DOCKER_IMAGE`: The name of the Docker image (default is project-2a-docs).
+1. `DOCKERFILE_PATH`: The path to the Dockerfile (default is docker/Dockerfile).
+1. `DOCKER_TAG`: The tag for the Docker image (default is latest).
+1. `CONTAINER_NAME`: The name of the container (default is project-2a-docs-container).
+1. `PORT`: The port the container will expose to the host (default is 8000).
+
+---
+
+This `README.md` now provides clear instructions on how to use the `Makefile` for building, running, stopping, and cleaning up Docker images and containers.

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -1,0 +1,3 @@
+mkdocs
+mkdocs-mermaid2-plugin
+mkdocs-material 


### PR DESCRIPTION
This PR resolves https://github.com/Mirantis/hmc/issues/351 by adding Dockerfile to allow local update/ development on the docs code base.