### PR TITLE
Fix typo in main.md

### DIFF
--- a/docs/template/main.md
+++ b/docs/template/main.md
@@ -1,6 +1,6 @@
 # Templates system
 
-By default, 2A delivers a set of default `ProviderTemplate`, `ClusterTemplate` and `SystemTemplate` objects:
+By default, 2A delivers a set of default `ProviderTemplate`, `ClusterTemplate` and `ServiceTemplate` objects:
 
 * `ProviderTemplate`
    The template containing the configuration of the provider, ex. k0smotron. Cluster-scoped.


### PR DESCRIPTION
For some reason the intro paragraph referenced ServiceTemplates as SystemTemplates.  Maybe an older artifact.