### PR TITLE
Update docs to reflect name change from ManagedCluster to ClusterDeployment

### DIFF
--- a/docs/clustertemplates/aws/hosted-control-plane.md
+++ b/docs/clustertemplates/aws/hosted-control-plane.md
@@ -21,7 +21,7 @@ reused with a management cluster.
 If you deployed your AWS Kubernetes cluster using Cluster API Provider AWS (CAPA)
 you can obtain all the necessary data with the commands below or use the
 template found below in the
-[HMC ManagedCluster manifest generation](#hmc-managedcluster-manifest-generation)
+[HMC ClusterDeployment manifest generation](#hmc-clusterdeployment-manifest-generation)
 section.
 
 If using the `aws-standalone-cp` template to deploy a hosted cluster it is
@@ -62,13 +62,13 @@ clusters you should setup additional connectivity rules like
 [VPC peering](https://docs.aws.amazon.com/whitepapers/latest/building-scalable-secure-multi-vpc-network-infrastructure/vpc-peering.html).
 
 
-## HMC ManagedCluster manifest
+## HMC ClusterDeployment manifest
 
-With all the collected data your `ManagedCluster` manifest will look similar to this:
+With all the collected data your `ClusterDeployment` manifest will look similar to this:
 
 ```yaml
 apiVersion: hmc.mirantis.com/v1alpha1
-kind: ManagedCluster
+kind: ClusterDeployment
 metadata:
   name: aws-hosted-cp
 spec:
@@ -97,14 +97,14 @@ spec:
 > In this example we're using the `us-west-1` region, but you should use the
 > region of your VPC.
 
-## HMC ManagedCluster manifest generation
+## HMC ClusterDeployment manifest generation
 
-Grab the following `ManagedCluster` manifest template and save it to a file
-named `managedcluster.yaml.tpl`:
+Grab the following `ClusterDeployment` manifest template and save it to a file
+named `clusterdeployment.yaml.tpl`:
 
 ```yaml
 apiVersion: hmc.mirantis.com/v1alpha1
-kind: ManagedCluster
+kind: ClusterDeployment
 metadata:
   name: aws-hosted
 spec:
@@ -129,10 +129,10 @@ spec:
       - "{{.status.networkStatus.securityGroups.node.id}}"
 ```
 
-Then run the following command to create the `managedcluster.yaml`:
+Then run the following command to create the `clusterdeployment.yaml`:
 
 ```
-kubectl get awscluster cluster -o go-template="$(cat managedcluster.yaml.tpl)" > managedcluster.yaml
+kubectl get awscluster cluster -o go-template="$(cat clusterdeployment.yaml.tpl)" > clusterdeployment.yaml
 ```
 ## Deployment Tips
 * Ensure HMC templates and the controller image are somewhere public and

--- a/docs/clustertemplates/aws/hosted-control-plane.md
+++ b/docs/clustertemplates/aws/hosted-control-plane.md
@@ -10,12 +10,12 @@ This section covers setting up for a k0smotron hosted control plane on AWS.
 -   Subnet ID which will be used along with AZ information
 -   AMI ID which will be used to deploy worker nodes
 
-Keep in mind that all control plane components for all managed clusters will
+Keep in mind that all control plane components for all cluster deployments will
 reside in the management cluster.
 
 ## Networking
 
-The networking resources in AWS which are needed for a managed cluster can be
+The networking resources in AWS which are needed for a cluster deployment can be
 reused with a management cluster.
 
 If you deployed your AWS Kubernetes cluster using Cluster API Provider AWS (CAPA)

--- a/docs/clustertemplates/aws/template-parameters.md
+++ b/docs/clustertemplates/aws/template-parameters.md
@@ -47,20 +47,20 @@ To access the nodes using the SSH protocol, several things should be configured:
 ### SSH keys
 
 Only one SSH key is supported and it should be added in AWS prior to creating
-the `ManagedCluster` object. The name of the key should then be placed under `.spec.config.sshKeyName`.
+the `ClusterDeployment` object. The name of the key should then be placed under `.spec.config.sshKeyName`.
 
 The same SSH key will be used for all machines and a bastion host.
 
 To enable bastion you should add `.spec.config.bastion.enabled` option in the
-`ManagedCluster` object to `true`.
+`ClusterDeployment` object to `true`.
 
 Full list of the bastion configuration options could be fould in [CAPA docs](https://cluster-api-aws.sigs.k8s.io/crd/#infrastructure.cluster.x-k8s.io/v1beta1.Bastion).
 
-The resulting `ManagedCluster` can look like this:
+The resulting `ClusterDeployment` can look like this:
 
 ```yaml
 apiVersion: hmc.mirantis.com/v1alpha1
-kind: ManagedCluster
+kind: ClusterDeployment
 metadata:
   name: cluster-1
 spec:
@@ -80,11 +80,11 @@ spec:
 > [additional steps](vpc-removal.md) may be needed for proper VPC removal.
 
 EKS templates use the parameters similar to AWS and resulting EKS
-`ManagedCluster` can look like this:
+`ClusterDeployment` can look like this:
 
 ```yaml
 apiVersion: hmc.mirantis.com/v1alpha1
-kind: ManagedCluster
+kind: ClusterDeployment
 metadata:
   name: cluster-1
 spec:

--- a/docs/clustertemplates/aws/template-parameters.md
+++ b/docs/clustertemplates/aws/template-parameters.md
@@ -29,7 +29,7 @@ AMI ID can be directly used in the `.amiID` parameter.
 
 #### CAPA prebuilt AMIs
 
-Use `clusterawsadm` to get available AMIs to deploy managed cluster:
+Use `clusterawsadm` to get available AMIs to deploy cluster deployment:
 
 ```bash
 clusterawsadm ami list

--- a/docs/clustertemplates/azure/hosted-control-plane.md
+++ b/docs/clustertemplates/azure/hosted-control-plane.md
@@ -12,7 +12,7 @@ reside in the management cluster.
 ## Pre-existing resources
 
 Certain resources will not be created automatically in a hosted control plane
-scenario thus they should be created in advance and provided in the `ManagedCluster`
+scenario thus they should be created in advance and provided in the `ClusterDeployment`
 object. You can reuse these resources with management cluster as described
 below.
 
@@ -63,13 +63,13 @@ kubectl get azurecluster <cluster-name> -o go-template='{{(index .spec.networkSp
 
 
 
-## HMC ManagedCluster manifest
+## HMC ClusterDeployment manifest
 
-With all the collected data your `ManagedCluster` manifest will look similar to this:
+With all the collected data your `ClusterDeployment` manifest will look similar to this:
 
 ```yaml
 apiVersion: hmc.mirantis.com/v1alpha1
-kind: ManagedCluster
+kind: ClusterDeployment
 metadata:
   name: azure-hosted-cp
 spec:
@@ -87,11 +87,11 @@ spec:
       securityGroupName: mgmt-cluster-node-nsg
 ```
 
-To simplify creation of the ManagedCluster object you can use the template below:
+To simplify creation of the ClusterDeployment object you can use the template below:
 
 ```yaml
 apiVersion: hmc.mirantis.com/v1alpha1
-kind: ManagedCluster
+kind: ClusterDeployment
 metadata:
   name: azure-hosted-cp
 spec:
@@ -117,7 +117,7 @@ kubectl get azurecluster <management-cluster-name> -o go-template="$(cat templat
 
 ## Cluster creation
 
-After applying `ManagedCluster` object you require to manually set the status of
+After applying `ClusterDeployment` object you require to manually set the status of
 the `AzureCluster` object due to current limitations (see
 [k0sproject/k0smotron#668](https://github.com/k0sproject/k0smotron/issues/668)).
 
@@ -142,7 +142,7 @@ To place finalizer you can execute the following command:
 kubectl patch azurecluster <cluster-name> --type=merge --patch 'metadata: {finalizers: [manual]}'
 ```
 
-When finalizer is placed you can remove the `ManagedCluster` as usual. Check that
+When finalizer is placed you can remove the `ClusterDeployment` as usual. Check that
 all `AzureMachines` objects are deleted successfully and remove finalizer you've
 placed to finish cluster deletion.
 

--- a/docs/clustertemplates/azure/template-parameters.md
+++ b/docs/clustertemplates/azure/template-parameters.md
@@ -5,7 +5,7 @@
 SSH public key can be passed to `.spec.config.sshPublicKey` (in case of hosted CP)
 parameter or `.spec.config.controlPlane.sshPublicKey` and
 `.spec.config.worker.sshPublicKey` parameters (in case of standalone CP)
-of the `ManagedCluster` object.
+of the `ClusterDeployment` object.
 
 It should be encoded in **base64** format.
 

--- a/docs/clustertemplates/vsphere/hosted-control-plane.md
+++ b/docs/clustertemplates/vsphere/hosted-control-plane.md
@@ -9,7 +9,7 @@ Keep in mind that all control plane components for all managed clusters will
 reside in the management cluster.
 
 
-## ManagedCluster manifest
+## ClusterDeployment manifest
 
 Hosted CP template has mostly identical parameters with standalone CP, you can
 check them in the [template parameters](template-parameters.md) section.
@@ -23,7 +23,7 @@ check them in the [template parameters](template-parameters.md) section.
 
 ```yaml
 apiVersion: hmc.mirantis.com/v1alpha1
-kind: ManagedCluster
+kind: ClusterDeployment
 metadata:
   name: cluster-1
 spec:

--- a/docs/clustertemplates/vsphere/template-parameters.md
+++ b/docs/clustertemplates/vsphere/template-parameters.md
@@ -1,9 +1,9 @@
 # vSphere cluster template parameters
 
-## ManagedCluster parameters
+## ClusterDeployment parameters
 
 To deploy managed cluster a number of parameters should be passed to the
-`ManagedCluster` object.
+`ClusterDeployment` object.
 
 ### Parameter list
 
@@ -26,13 +26,13 @@ To obtain vSphere certificate thumbprint you can use the following command:
 curl -sw %{certs} https://vcenter.example.com | openssl x509 -sha256 -fingerprint -noout | awk -F '=' '{print $2}'
 ```
 
-## Example of ManagedCluster CR
+## Example of ClusterDeployment CR
 
-With all above parameters provided your `ManagedCluster` can look like this:
+With all above parameters provided your `ClusterDeployment` can look like this:
 
 ```yaml
 apiVersion: hmc.mirantis.com/v1alpha1
-kind: ManagedCluster
+kind: ClusterDeployment
 metadata:
   name: cluster-1
 spec:
@@ -82,7 +82,7 @@ public key to configure SSH access.
 SSH public key can be passed to `.spec.config.ssh.publicKey` (in case of
 hosted CP) parameter or `.spec.config.controlPlane.ssh.publicKey` and
 `.spec.config.worker.ssh.publicKey` parameters (in case of standalone CP) of the
-`ManagedCluster` object.
+`ClusterDeployment` object.
 
 SSH public key must be passed literally as a string.
 
@@ -119,7 +119,7 @@ used:
 | `.network`    | `/DC/network/Net` | Network path        |
 
 As with resource parameters the position of these parameters in the
-`ManagedCluster` depends on deployment type and these parameters are used in:
+`ClusterDeployment` depends on deployment type and these parameters are used in:
 
 - `.spec.config` in case of hosted CP deployment.
 - `.spec.config.controlPlane` in in case of standalone CP for control plane

--- a/docs/clustertemplates/vsphere/template-parameters.md
+++ b/docs/clustertemplates/vsphere/template-parameters.md
@@ -2,7 +2,7 @@
 
 ## ClusterDeployment parameters
 
-To deploy managed cluster a number of parameters should be passed to the
+To create a cluster deployment a number of parameters should be passed to the
 `ClusterDeployment` object.
 
 ### Parameter list

--- a/docs/credential/main.md
+++ b/docs/credential/main.md
@@ -9,8 +9,8 @@ The following is the process of passing credentials to the system:
 
 1. Provider specific `ClusterIdentity` and `Secret` are created
 2. `Credential` object is created referencing `ClusterIdentity` from step **1**.
-3. The `Credential` object is then referenced in the `ManagedCluster`.
-4. Optionally, certain credentials MAY be propagated to the `ManagedCluster` after it is created.
+3. The `Credential` object is then referenced in the `ClusterDeployment`.
+4. Optionally, certain credentials MAY be propagated to the `ClusterDeployment` after it is created.
 
 The following diagram illustrates the process:
 
@@ -18,8 +18,8 @@ The following diagram illustrates the process:
 flowchart TD
   Step1["<b>Step 1</b> (Lead Engineer):<br/>Create ClusterIdentity and Secret objects where ClusterIdentity references Secret"]
   Step1 --> Step2["<b>Step 2</b> (Any Engineer):<br/>Create Credential object referencing ClusterIdentity"]
-  Step2 --> Step3["<b>Step 3</b> (Any Engineer):<br/>Create ManagedCluster referencing Credential object"]
-  Step3 --> Step4["<b>Step 4</b> (Any Engineer):<br/>Apply ManagedCluster, wait for provisioning & reconciliation, then propagate credentials to nodes if necessary"]
+  Step2 --> Step3["<b>Step 3</b> (Any Engineer):<br/>Create ClusterDeployment referencing Credential object"]
+  Step3 --> Step4["<b>Step 4</b> (Any Engineer):<br/>Apply ClusterDeployment, wait for provisioning & reconciliation, then propagate credentials to nodes if necessary"]
 ```
 
 By design steps 1 and 2 should be executed by the lead engineer who has
@@ -31,7 +31,7 @@ like `ClusterIdentity`.
 
 The `Credential` object acts like a reference to the underlying credentials. It
 is namespace-scoped, which means that it must be in the same `Namespace` with
-the `ManagedCluster` it is referenced in. Actual credentials can be located in
+the `ClusterDeployment` it is referenced in. Actual credentials can be located in
 any namespace.
 
 ### Example
@@ -89,7 +89,7 @@ use them without seeing values and even any access to underlying
 infrastructure platform.
 
 The process is fully automated and credentials will be propagated automatically
-within the `ManagedCluster` reconciliation process, user only needs to provide
+within the `ClusterDeployment` reconciliation process, user only needs to provide
 the correct [Credential object](#credential-object).
 
 ### Provider specific notes

--- a/docs/credential/main.md
+++ b/docs/credential/main.md
@@ -61,7 +61,7 @@ present.
 
 ## Cloud provider credentials propagation
 
-Some components in the managed cluster require cloud provider credentials to be
+Some components in the cluster deployment require cloud provider credentials to be
 passed for proper functioning. As an example Cloud Controller Manager (CCM)
 requires provider credentials to create load balancers and provide other
 functionality.
@@ -77,7 +77,7 @@ to pass all necessary credentials. This approach has several problems:
 
 To solve these problems in Project 2A we're using special controller which
 aggregates all necessary data from CAPI provider resources (like
-`ClusterIdentity`) and creates secrets directly on the managed cluster.
+`ClusterIdentity`) and creates secrets directly on the cluster deployment.
 
 This eliminates the need to pass anything credentials-related to `cloud-init`
 and makes it possible to rotate credentials automatically without the need for

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -62,7 +62,7 @@ managing Kubernetes clusters. It enables Cluster API (CAPI) to provision and
 manage clusters on a specific infrastructure platform (e.g., AWS, Azure, VMware,
 OpenStack, etc.).
 
-### Managed cluster
+### Cluster deployment
 A Kubernetes cluster created and managed by Project 2A.
 
 ### Mutli Cluster Service

--- a/docs/quick-start/2a-installation.md
+++ b/docs/quick-start/2a-installation.md
@@ -141,7 +141,7 @@ kyverno-X-Y-Z         true
 ### Next Step
 
 Now you can configure your Infrastructure Provider of choice and create your
-first Managed Cluster.
+first Cluster Deployment.
 
 Jump to any of the following Infrastructure Providers for specific instructions:
 

--- a/docs/quick-start/aws.md
+++ b/docs/quick-start/aws.md
@@ -155,15 +155,15 @@ kubectl apply -f aws-cluster-identity-cred.yaml
 ## Step 5: Create Your First Managed Cluster
 
 Create a YAML with the specification of your Managed Cluster and save it as
-`my-aws-managedcluster1.yaml`.
+`my-aws-clusterdeployment1.yaml`.
 
-Here is an example of a `ManagedCluster` YAML file:
+Here is an example of a `ClusterDeployment` YAML file:
 
 ```yaml
 apiVersion: hmc.mirantis.com/v1alpha1
-kind: ManagedCluster
+kind: ClusterDeployment
 metadata:
-  name: my-aws-managedcluster1
+  name: my-aws-clusterdeployment1
   namespace: hmc-system
 spec:
   template: aws-standalone-cp-0-0-3
@@ -179,22 +179,22 @@ spec:
 Apply the YAML to your management cluster:
 
 ```bash
-kubectl apply -f my-aws-managedcluster1.yaml
+kubectl apply -f my-aws-clusterdeployment1.yaml
 ```
 
 There will be a delay as the cluster finishes provisioning. Follow the
 provisioning process with the following command:
 
 ```bash
-kubectl -n hmc-system get managedcluster.hmc.mirantis.com my-aws-managedcluster1 --watch
+kubectl -n hmc-system get clusterdeployment.hmc.mirantis.com my-aws-clusterdeployment1 --watch
 ```
 
 After the cluster is `Ready`, you can access it via the kubeconfig, like this:
 
 ```bash
-kubectl -n hmc-system get secret my-aws-managedcluster1-kubeconfig -o jsonpath='{.data.value}' | base64 -d > my-aws-managedcluster1-kubeconfig.kubeconfig
+kubectl -n hmc-system get secret my-aws-clusterdeployment1-kubeconfig -o jsonpath='{.data.value}' | base64 -d > my-aws-clusterdeployment1-kubeconfig.kubeconfig
 ```
 
 ```bash
-KUBECONFIG="my-aws-managedcluster1-kubeconfig.kubeconfig" kubectl get pods -A
+KUBECONFIG="my-aws-clusterdeployment1-kubeconfig.kubeconfig" kubectl get pods -A
 ```

--- a/docs/quick-start/aws.md
+++ b/docs/quick-start/aws.md
@@ -152,9 +152,9 @@ Apply the YAML to your cluster:
 kubectl apply -f aws-cluster-identity-cred.yaml
 ```
 
-## Step 5: Create Your First Managed Cluster
+## Step 5: Create Your First Cluster Deployment
 
-Create a YAML with the specification of your Managed Cluster and save it as
+Create a YAML with the specification of your Cluster Deployment and save it as
 `my-aws-clusterdeployment1.yaml`.
 
 Here is an example of a `ClusterDeployment` YAML file:

--- a/docs/quick-start/azure.md
+++ b/docs/quick-start/azure.md
@@ -184,18 +184,18 @@ kubectl apply -f azure-cluster-identity-cred.yaml
 
 This creates the `Credential` object that will be used in the next step.
 
-## Step 6: Create your first ManagedCluster
+## Step 6: Create your first ClusterDeployment
 
 Create a YAML with the specification of your managed Cluster and save it as
-`my-azure-managedcluster1.yaml`.
+`my-azure-clusterdeployment1.yaml`.
 
-Here is an example of a `ManagedCluster` YAML file:
+Here is an example of a `ClusterDeployment` YAML file:
 
 ```yaml
 apiVersion: hmc.mirantis.com/v1alpha1
-kind: ManagedCluster
+kind: ClusterDeployment
 metadata:
-  name: my-azure-managedcluster1
+  name: my-azure-clusterdeployment1
   namespace: hmc-system
 spec:
   template: azure-standalone-cp-0-0-3
@@ -212,22 +212,22 @@ spec:
 Apply the YAML to your management cluster:
 
 ```shell
-kubectl apply -f my-azure-managedcluster1.yaml
+kubectl apply -f my-azure-clusterdeployment1.yaml
 ```
 
 There will be a delay as the cluster finishes provisioning. Follow the
 provisioning process with the following command:
 
 ```shell
-kubectl -n hmc-system get managedcluster.hmc.mirantis.com my-azure-managedcluster1 --watch
+kubectl -n hmc-system get clusterdeployment.hmc.mirantis.com my-azure-clusterdeployment1 --watch
 ```
 
 After the cluster is `Ready`, you can access it via the kubeconfig, like this:
 
 ```shell
-kubectl -n hmc-system get secret my-azure-managedcluster1-kubeconfig -o jsonpath='{.data.value}' | base64 -d > my-azure-managedcluster1-kubeconfig.kubeconfig
+kubectl -n hmc-system get secret my-azure-clusterdeployment1-kubeconfig -o jsonpath='{.data.value}' | base64 -d > my-azure-clusterdeployment1-kubeconfig.kubeconfig
 ```
 
 ```shell
-KUBECONFIG="my-azure-managedcluster1-kubeconfig.kubeconfig" kubectl get pods -A
+KUBECONFIG="my-azure-clusterdeployment1-kubeconfig.kubeconfig" kubectl get pods -A
 ```

--- a/docs/quick-start/vsphere.md
+++ b/docs/quick-start/vsphere.md
@@ -139,15 +139,15 @@ kubectl apply -f vsphere-cluster-identity-cred.yaml
 ## Step 4: Create your first Managed Cluster
 
 Create a YAML with the specification of your Managed Cluster and save it as
-`my-vsphere-managedcluster1.yaml`.
+`my-vsphere-clusterdeployment1.yaml`.
 
-Here is an example of a `ManagedCluster` YAML file:
+Here is an example of a `ClusterDeployment` YAML file:
 
 ```yaml
 apiVersion: hmc.mirantis.com/v1alpha1
-kind: ManagedCluster
+kind: ClusterDeployment
 metadata:
-  name: my-vsphere-managedcluster1
+  name: my-vsphere-clusterdeployment1
   namespace: hmc-system
 spec:
   template: vsphere-standalone-cp-0-0-3
@@ -183,22 +183,22 @@ spec:
 Apply the YAML to your management cluster:
 
 ```shell
-kubectl apply -f my-vsphere-managedcluster1.yaml
+kubectl apply -f my-vsphere-clusterdeployment1.yaml
 ```
 
 There will be a delay as the cluster finishes provisioning. Follow the
 provisioning process with the following command:
 
 ```shell
-kubectl -n hmc-system get managedcluster.hmc.mirantis.com my-vsphere-managedcluster1 --watch
+kubectl -n hmc-system get clusterdeployment.hmc.mirantis.com my-vsphere-clusterdeployment1 --watch
 ```
 
 After the cluster is `Ready`, you can access it via the kubeconfig, like this:
 
 ```shell
-kubectl -n hmc-system get secret my-vsphere-managedcluster1-kubeconfig -o jsonpath='{.data.value}' | base64 -d > my-vsphere-managedcluster1-kubeconfig.kubeconfig
+kubectl -n hmc-system get secret my-vsphere-clusterdeployment1-kubeconfig -o jsonpath='{.data.value}' | base64 -d > my-vsphere-clusterdeployment1-kubeconfig.kubeconfig
 ```
 
 ```shell
-KUBECONFIG="my-vsphere-managedcluster1-kubeconfig.kubeconfig" kubectl get pods -A
+KUBECONFIG="my-vsphere-clusterdeployment1-kubeconfig.kubeconfig" kubectl get pods -A
 ```

--- a/docs/quick-start/vsphere.md
+++ b/docs/quick-start/vsphere.md
@@ -136,9 +136,9 @@ Apply the YAML to your cluster:
 kubectl apply -f vsphere-cluster-identity-cred.yaml
 ```
 
-## Step 4: Create your first Managed Cluster
+## Step 4: Create your first Cluster Deployment
 
-Create a YAML with the specification of your Managed Cluster and save it as
+Create a YAML with the specification of your Cluster Deployment and save it as
 `my-vsphere-clusterdeployment1.yaml`.
 
 Here is an example of a `ClusterDeployment` YAML file:

--- a/docs/rbac/roles.md
+++ b/docs/rbac/roles.md
@@ -63,7 +63,7 @@ A user with the `Global Admin` role is authorized to perform the following actio
    `Template Chains`
 7. Manage upgrade sequences for `Cluster` and `Service Templates`
 8. Manage and deploy Services across multiple clusters in any namespace by modifying `MultiClusterService` resources
-9. Manage `ManagedClusters` in any namespace
+9. Manage `ClusterDeployments` in any namespace
 10. Manage `Credentials` and `secrets` in any namespace
 11. Upgrade 2A
 12. Uninstall 2A
@@ -99,7 +99,7 @@ A user with the `Global Viewer` role is authorized to perform the following acti
 5. List and view detailed information about Flux `HelmRepositories` and `HelmCharts` in any namespace
 6. View access rules for `Cluster` and `Service Templates`, including `Template Chains` in any namespace
 7. View full details about the created `MultiClusterService` objects
-8. List and view detailed information about `ManagedClusters` in any namespace
+8. List and view detailed information about `ClusterDeployments` in any namespace
 9. List and view detailed information about created `Credentials` and `secrets` in any namespace
 
 
@@ -116,7 +116,7 @@ The `Namespace Admin` role provides full administrative access within namespace.
 
 **Permissions**:
 
-1. Full access to `ManagedClusters`, `Credentials`, `Cluster` and `Service Templates` in the namespace
+1. Full access to `ClusterDeployments`, `Credentials`, `Cluster` and `Service Templates` in the namespace
 2. Full access to `Template Chains` in the namespace
 3. Full access to Flux `HelmRepositories` and `HelmCharts` in the namespace
 
@@ -124,7 +124,7 @@ The `Namespace Admin` role provides full administrative access within namespace.
 
 A user with the `Namespace Admin` role is authorized to perform the following actions within the namespace:
 
-1. Create and manage all `ManagedClusters` in the namespace
+1. Create and manage all `ClusterDeployments` in the namespace
 2. Create and manage `Cluster` and `Service Templates` in the namespace
 3. Manage the distribution and upgrade sequences of Templates within the namespace
 4. Create and manage Flux `HelmRepositories` and `HelmCharts` in the namespace
@@ -133,7 +133,7 @@ A user with the `Namespace Admin` role is authorized to perform the following ac
 
 ### Namespace Editor
 
-The `Namespace Editor` role allows users to create and modify `ManagedClusters` within namespace using predefined
+The `Namespace Editor` role allows users to create and modify `ClusterDeployments` within namespace using predefined
 `Credentials` and `Templates`.
 
 **Name**: `hmc-namespace-editor-role`
@@ -144,7 +144,7 @@ The `Namespace Editor` role allows users to create and modify `ManagedClusters` 
 
 **Permissions**:
 
-1. Full access to `ManagedClusters` in the allowed namespace
+1. Full access to `ClusterDeployments` in the allowed namespace
 2. Read access to `Credentials`, `Cluster` and `Service Templates`, and `TemplateChains` in the namespace
 3. Read access to Flux `HelmRepositories` and `HelmCharts` in the namespace
 
@@ -152,7 +152,7 @@ The `Namespace Editor` role allows users to create and modify `ManagedClusters` 
 
 A user with the `Namespace Editor` role has the following permissions in the namespace:
 
-1. Can create and manage `ManagedCluster` objects in the namespace using existing `Credentials` and `Templates`
+1. Can create and manage `ClusterDeployment` objects in the namespace using existing `Credentials` and `Templates`
 2. Can list and view detailed information about the `Credentials` available in the namespace
 3. Can list and view detailed information about the available `Cluster` and `Service Templates` and the `Templates'`
    upgrade sequences
@@ -171,7 +171,7 @@ The `Namespace Viewer` role grants read-only access to resources within a namesp
 
 **Permissions**:
 
-1. Read access to `ManagedClusters` in the namespace
+1. Read access to `ClusterDeployments` in the namespace
 2. Read access to `Credentials`, `Cluster` and `Service Templates`, and `TemplateChains` in the namespace
 3. Read access to Flux `HelmRepositories` and `HelmCharts` in the namespace
 
@@ -179,7 +179,7 @@ The `Namespace Viewer` role grants read-only access to resources within a namesp
 
 A user with the `Namespace Viewer` role has the following permissions in the namespace:
 
-1. Can list and view detailed information about all the `ManagedCluster` objects in the allowed namespace
+1. Can list and view detailed information about all the `ClusterDeployment` objects in the allowed namespace
 2. Can list and view detailed information about `Credentials` available in the specific namespace
 3. Can list and view detailed information about available `Cluster` and `Service Templates` and the `Templates'`
    upgrade sequences

--- a/docs/rbac/roles.md
+++ b/docs/rbac/roles.md
@@ -20,7 +20,7 @@ permissions:
 | Cluster and Service Templates    | r/w          | r/o           | r/w             | r/o              | r/o              |
 | Credentials                      | r/w          | r/o           | r/w             | r/o              | r/o              |
 | Flux Helm objects                | r/w          | r/o           | r/w             | r/o              | r/o              |
-| Cluster Deployments                 | r/w          | r/o           | r/w             | r/w              | r/o              |
+| Cluster Deployments              | r/w          | r/o           | r/w             | r/w              | r/o              |
 
 
 ## Roles definition

--- a/docs/rbac/roles.md
+++ b/docs/rbac/roles.md
@@ -20,7 +20,7 @@ permissions:
 | Cluster and Service Templates    | r/w          | r/o           | r/w             | r/o              | r/o              |
 | Credentials                      | r/w          | r/o           | r/w             | r/o              | r/o              |
 | Flux Helm objects                | r/w          | r/o           | r/w             | r/o              | r/o              |
-| Managed Clusters                 | r/w          | r/o           | r/w             | r/w              | r/o              |
+| Cluster Deployments                 | r/w          | r/o           | r/w             | r/w              | r/o              |
 
 
 ## Roles definition

--- a/docs/template/byo-templates.md
+++ b/docs/template/byo-templates.md
@@ -67,8 +67,8 @@ The controller will automatically create the `HelmChart` object based on the cha
 `.spec.helm.chartSpec`.
 
 > NOTE:
-> `ClusterTemplate` and `ServiceTemplate` objects should reside in the same namespace as the `ManagedCluster`
-> referencing them. The `ManagedCluster` can't reference the Template from another namespace (the creation request will
+> `ClusterTemplate` and `ServiceTemplate` objects should reside in the same namespace as the `ClusterDeployment`
+> referencing them. The `ClusterDeployment` can't reference the Template from another namespace (the creation request will
 > be declined by the admission webhook). All `ClusterTemplates` and `ServiceTemplates` shipped with HMC reside in the
 > system namespace (defaults to `hmc-system`). To get the instructions on how to distribute Templates along multiple
 > namespaces, read [Template Life Cycle Management](main.md#template-life-cycle-management).
@@ -252,12 +252,12 @@ The aforedescribed attributes are being checked sticking to the following rules:
 * both the exact and constraint version of the same type (e.g. `k8sVersion` and `k8sConstraint`) must
 be set otherwise no check is performed;
 * if a `ClusterTemplate` object's providers contract version does not satisfy contract versions
-from the related `ProviderTemplate` object, the updates to the `ManagedCluster` object will be blocked;
+from the related `ProviderTemplate` object, the updates to the `ClusterDeployment` object will be blocked;
 * if a `ProviderTemplate` object's `CAPI` contract version
 (e.g. in a `v1beta1: v1beta1_v1beta2` key-value pair, the key `v1beta1` is the core `CAPI` contract version)
 is not listed in the core `CAPI` `ProviderTemplate` object, the updates to the `Management` object will be blocked;
 * if a `ClusterTemplate` object's exact kubernetes version does not satisfy the kubernetes version
-constraint from the related `ServiceTemplate` object, the updates to the `ManagedCluster` object will be blocked.
+constraint from the related `ServiceTemplate` object, the updates to the `ClusterDeployment` object will be blocked.
 
 ## Remove Templates shipped with HMC
 

--- a/docs/template/main.md
+++ b/docs/template/main.md
@@ -7,7 +7,7 @@ By default, 2A delivers a set of default `ProviderTemplate`, `ClusterTemplate` a
 * `ClusterTemplate`
    The template containing the configuration of the cluster objects. Namespace-scoped.
 * `ServiceTemplate`
-   The template containing the configuration of the service to be installed on the managed cluster. Namespace-scoped.
+   The template containing the configuration of the service to be installed on the cluster deployment. Namespace-scoped.
 
 All Templates are immutable. You can also build your own templates and use them for deployment along with the
 templates shipped with 2A.

--- a/docs/usage/airgap.md
+++ b/docs/usage/airgap.md
@@ -50,7 +50,7 @@ following:
       extensions charts within the `extensions` directory.  All of these charts
       will be pushed to a chart repository within a registry.
     - `scripts/airgap-push.sh` - A script that will aid in re-tagging and
-      pushing the `ManagedCluster` required charts and images to a desired
+      pushing the `ClusterDeployment` required charts and images to a desired
       registry.
 
 2. Extract and use the `airgap-push.sh` script to push the `extensions` images
@@ -91,7 +91,7 @@ following:
         --set controller.defaultRegistryURL="oci://<chart-repository>"
       ```
 
-5. Within the `spec:` for your desired `ManagedCluster` object, specify the
+5. Within the `spec:` for your desired `ClusterDeployment` object, specify the
    custom image registry and chart repository to be used (the registry and chart
    repository where the `extensions` bundle and charts were pushed).
 

--- a/docs/usage/cluster-update.md
+++ b/docs/usage/cluster-update.md
@@ -1,18 +1,18 @@
 # Managed Cluster update
 
-To update the `ManagedCluster`, update `.spec.template` in the `ManagedCluster`
+To update the `ClusterDeployment`, update `.spec.template` in the `ClusterDeployment`
 object to the new `ClusterTemplate` name:
 
 Run:
 
 ```shell
-kubectl patch managedcluster.hmc <cluster-name> -n <namespace> --patch '{"spec":{"template":"<new-template-name>"}}' --type=merge
+kubectl patch clusterdeployment.hmc <cluster-name> -n <namespace> --patch '{"spec":{"template":"<new-template-name>"}}' --type=merge
 ```
 
-Then, check the status of the `ManagedCluster` object:
+Then, check the status of the `ClusterDeployment` object:
 
 ```shell
-kubectl get managedcluster.hmc <cluster-name> -n <namespace>
+kubectl get clusterdeployment.hmc <cluster-name> -n <namespace>
 ```
 
 In the commands above, replace the parameters enclosed in angle brackets with
@@ -22,7 +22,7 @@ To get more details, run the previous command with the `-o=yaml` option and
 check the `.status.conditions`.
 
 > NOTE:
-> The `ManagedCluster` is allowed to be updated to specific templates only.
+> The `ClusterDeployment` is allowed to be updated to specific templates only.
 > The templates available for the update are defined in the
 > `ClusterTemplateChain` objects. Also, the `AccessManagement` object should
 > contain properly configured `spec.accessRules` with the list of
@@ -31,5 +31,5 @@ check the `.status.conditions`.
 > [Template Life Cycle Management](../template/main.md/#template-life-cycle-management).
 
 <!---
-TODO: Later all `ClusterTemplates` that are available for the update will be shown in the `ManagedCluster` status.
+TODO: Later all `ClusterTemplates` that are available for the update will be shown in the `ClusterDeployment` status.
 -->

--- a/docs/usage/cluster-update.md
+++ b/docs/usage/cluster-update.md
@@ -1,4 +1,4 @@
-# Managed Cluster update
+# Cluster Deployment update
 
 To update the `ClusterDeployment`, update `.spec.template` in the `ClusterDeployment`
 object to the new `ClusterTemplate` name:

--- a/docs/usage/create-cluster-deployment.md
+++ b/docs/usage/create-cluster-deployment.md
@@ -27,13 +27,13 @@ For details about the templates in Project 2A, see the [Templates system](../tem
 > - [AWS Hosted Control Plane](../clustertemplates/aws/hosted-control-plane.md)
 > - [vSphere Hosted Control Plane](../clustertemplates/vsphere/hosted-control-plane.md)
 
-### Step 3: Create the ManagedCluster Object YAML Configuration
+### Step 3: Create the ClusterDeployment Object YAML Configuration
 
-- Create the file with the `ManagedCluster` configuration:
+- Create the file with the `ClusterDeployment` configuration:
 
     ```yaml
     apiVersion: hmc.mirantis.com/v1alpha1
-    kind: ManagedCluster
+    kind: ClusterDeployment
     metadata:
       name: <cluster-name>
       namespace: <hmc-system-namespace>
@@ -53,11 +53,11 @@ For details about the templates in Project 2A, see the [Templates system](../tem
 
 Following is an interpolated example.
 
-> EXAMPLE: `ManagedCluster` for AWS Infrastructure Provider Object Example
+> EXAMPLE: `ClusterDeployment` for AWS Infrastructure Provider Object Example
 > 
 > ```yaml
 > apiVersion: hmc.mirantis.com/v1alpha1
-> kind: ManagedCluster
+> kind: ClusterDeployment
 > metadata:
 >   name: my-managed-cluster
 >   namespace: hmc-system
@@ -73,26 +73,26 @@ Following is an interpolated example.
 >       instanceType: t3.small
 > ```
 
-### Step 4: Apply the `ManagedCluster` Configuration to Create it
+### Step 4: Apply the `ClusterDeployment` Configuration to Create it
 
-- Apply the `ManagedCluster` object to your Project 2A deployment:
+- Apply the `ClusterDeployment` object to your Project 2A deployment:
 
 	```shell
-	kubectl apply -f managedcluster.yaml
+	kubectl apply -f clusterdeployment.yaml
 	```
 
-### Step 5: Check the Status of the `ManagedCluster` Object
+### Step 5: Check the Status of the `ClusterDeployment` Object
 
-- Check the status of the newly created `ManagedCluster`:
+- Check the status of the newly created `ClusterDeployment`:
 
 	```shell
-	kubectl -n <namespace> get managedcluster.hmc <cluster-name> -o=yaml
+	kubectl -n <namespace> get clusterdeployment.hmc <cluster-name> -o=yaml
 	```
 
 > INFO:
 > 
 > Reminder: `<namespace>` and `<cluster-name>` are defined in the `.metadata`
-> section of the `ManagedCluster` object you created above.
+> section of the `ClusterDeployment` object you created above.
 
 ### Step 6: Wait for Infrastructure and Cluster to be Provisioned
 
@@ -122,19 +122,19 @@ Following is an interpolated example.
 
 ## Dry Run
 
-Project 2A `ManagedCluster` supports two modes: with and without `.spec.dryRun`
+Project 2A `ClusterDeployment` supports two modes: with and without `.spec.dryRun`
 (defaults to `false`).
 
-If no configuration (`.spec.config`) is specified, the `ManagedCluster` object
+If no configuration (`.spec.config`) is specified, the `ClusterDeployment` object
 will be populated with defaults (default configuration can be found in the
 corresponding `Template` status) and automatically have `.spec.dryRun` set to
 `true`.
 
-> EXAMPLE: `ManagedCluster` with default configuration
+> EXAMPLE: `ClusterDeployment` with default configuration
 > 
 > ```yaml
 > apiVersion: hmc.mirantis.com/v1alpha1
-> kind: ManagedCluster
+> kind: ClusterDeployment
 > metadata:
 >   name: my-managed-cluster
 >   namespace: hmc-system
@@ -170,13 +170,13 @@ After you adjust your configuration and ensure that it passes validation
 (`TemplateReady` condition from `.status.conditions`), remove the `.spec.dryRun`
 flag to proceed with the deployment.
 
-Here is an example of a `ManagedCluster` object that passed the validation:
+Here is an example of a `ClusterDeployment` object that passed the validation:
 
-> EXAMPLE: `ManagedCluster` object that passed the validation
+> EXAMPLE: `ClusterDeployment` object that passed the validation
 > 
 > ```yaml
 > apiVersion: hmc.mirantis.com/v1alpha1
-> kind: ManagedCluster
+> kind: ClusterDeployment
 > metadata:
 >   name: my-managed-cluster
 >   namespace: hmc-system
@@ -205,7 +205,7 @@ Here is an example of a `ManagedCluster` object that passed the validation:
 >       status: "True"
 >       type: HelmChartReady
 >     - lastTransitionTime: "2024-07-22T09:25:49Z"
->       message: ManagedCluster is ready
+>       message: ClusterDeployment is ready
 >       reason: Succeeded
 >       status: "True"
 >       type: Ready
@@ -224,7 +224,7 @@ Here is an example of a `ManagedCluster` object that passed the validation:
 
 > NOTE:
 >
-> Ensure you have no Project 2A `ManagedCluster` objects left in the cluster
+> Ensure you have no Project 2A `ClusterDeployment` objects left in the cluster
 > prior to Management deletion.
 
 2. Remove the `hmc` Helm release:

--- a/docs/usage/create-cluster-deployment.md
+++ b/docs/usage/create-cluster-deployment.md
@@ -1,4 +1,4 @@
-# Create Managed Cluster
+# Create Cluster Deployment
 
 ## Creation Process 
 
@@ -111,9 +111,9 @@ Following is an interpolated example.
 > clusterctl describe cluster <cluster-name> -n <namespace> --show-conditions all
 > ```
 
-### Step 7: Retrieve Kubernetes Configuration of Your Managed Cluster
+### Step 7: Retrieve Kubernetes Configuration of Your Cluster Deployment
 
-- Retrieve the Kubernetes configuration of your managed cluster when it is
+- Retrieve the Kubernetes configuration of your cluster deployment when it is
   finished provisioning:
 
     ```shell

--- a/docs/usage/create-multiclusterservice.md
+++ b/docs/usage/create-multiclusterservice.md
@@ -27,12 +27,12 @@ spec:
 
 ## Matching Multiple Clusters
 
-Consider the following example where 2 clusters have been deployed using ManagedCluster objects:
+Consider the following example where 2 clusters have been deployed using ClusterDeployment objects:
 ```sh
-➜  ~ kubectl get managedclusters.hmc.mirantis.com -n hmc-system
+➜  ~ kubectl get clusterdeployments.hmc.mirantis.com -n hmc-system
 NAME             READY   STATUS
-dev-cluster-1   True    ManagedCluster is ready
-dev-cluster-2   True    ManagedCluster is ready
+dev-cluster-1   True    ClusterDeployment is ready
+dev-cluster-2   True    ClusterDeployment is ready
 ➜  ~ 
 ➜  ~ 
 ➜  ~  kubectl get cluster -n hmc-system --show-labels
@@ -42,10 +42,10 @@ dev-cluster-2                  Provisioned   3h10m             app.kubernetes.io
 ```
 
 > EXAMPLE: 
-> Spec for `dev-cluster-1` ManagedCluster (only sections relevant to beach-head services):
+> Spec for `dev-cluster-1` ClusterDeployment (only sections relevant to beach-head services):
 > ```yaml
 > apiVersion: hmc.mirantis.com/v1alpha1
-> kind: ManagedCluster
+> kind: ClusterDeployment
 > metadata:
 >   . . . 
 >   name: dev-cluster-1
@@ -64,10 +64,10 @@ dev-cluster-2                  Provisioned   3h10m             app.kubernetes.io
 >   . . .
 > ```
 > 
-> Spec for `dev-cluster-2` ManagedCluster (only sections relevant to beach-head services):
+> Spec for `dev-cluster-2` ClusterDeployment (only sections relevant to beach-head services):
 > ```yaml
 > apiVersion: hmc.mirantis.com/v1alpha1
-> kind: ManagedCluster
+> kind: ClusterDeployment
 > metadata:
 >   . . .
 >   name: dev-cluster-2
@@ -83,7 +83,7 @@ dev-cluster-2                  Provisioned   3h10m             app.kubernetes.io
 >   . . .
 > ```
 
-> NOTE: See [Deploy beach-head Services using Managed Cluster](deploy-services-managedcluster.md) for how to use beach-head services with ManagedCluster.
+> NOTE: See [Deploy beach-head Services using Managed Cluster](deploy-services-clusterdeployment.md) for how to use beach-head services with ClusterDeployment.
 
 Now the following `global-ingress` MultiClusterService object is created with the following spec:
 
@@ -110,34 +110,34 @@ version 4.11.3 of ingress-nginx service on it.
 
 ### Configuring Custom Values
 
-Refer to "Configuring Custom Values" in [Deploy beach-head Services using Managed Cluster](./deploy-services-managedcluster.md).
+Refer to "Configuring Custom Values" in [Deploy beach-head Services using Managed Cluster](./deploy-services-clusterdeployment.md).
 
 ### Templating Custom Values
 
-Refer to "Templating Custom Values" in [Deploy beach-head Services using Managed Cluster](./deploy-services-managedcluster.md).
+Refer to "Templating Custom Values" in [Deploy beach-head Services using Managed Cluster](./deploy-services-clusterdeployment.md).
 
 ### Services Priority and Conflict
 
-The `.spec.servicesPriority` field is used to specify the priority for the services managed by a ManagedCluster or MultiClusterService object.
+The `.spec.servicesPriority` field is used to specify the priority for the services managed by a ClusterDeployment or MultiClusterService object.
 Considering the example above:
 
-1. ManagedCluster `dev-cluster-1` manages deployment of kyverno (v3.2.6) and ingress-nginx (v4.11.0) with `servicesPriority=100` on its cluster.
-2. ManagedCluster `dev-cluster-2` manages deployment of ingress-nginx (v4.11.0) with `servicesPriority=500` on its cluster.
+1. ClusterDeployment `dev-cluster-1` manages deployment of kyverno (v3.2.6) and ingress-nginx (v4.11.0) with `servicesPriority=100` on its cluster.
+2. ClusterDeployment `dev-cluster-2` manages deployment of ingress-nginx (v4.11.0) with `servicesPriority=500` on its cluster.
 3. MultiClusterService `global-ingress` manages deployment of ingress-nginx (v4.11.3) with `servicesPriority=300` on both clusters.
 
 This scenario presents a conflict on both the clusters as the MultiClusterService is attempting to deploy v4.11.3 of ingress-nginx
-on both whereas the ManagedCluster for each is attempting to deploy v4.11.0 of ingress-nginx.
+on both whereas the ClusterDeployment for each is attempting to deploy v4.11.0 of ingress-nginx.
 
 This is where `.spec.servicesPriority` can be used to specify who gets the priority. Higher number means higer priority and vice versa. In this example:
-1. MultiClusterService "global-ingress" will take precedence over ManagedCluster "dev-cluster-1" and ingress-nginx (v4.11.3) defined in MultiClusterService object will be deployed on the cluster.
-2. ManagedCluster "dev-cluster-2" will take precedence over MultiClusterService "global-ingress" and ingress-nginx (v4.11.0) defined in ManagedCluster object will be deployed on the cluster.
+1. MultiClusterService "global-ingress" will take precedence over ClusterDeployment "dev-cluster-1" and ingress-nginx (v4.11.3) defined in MultiClusterService object will be deployed on the cluster.
+2. ClusterDeployment "dev-cluster-2" will take precedence over MultiClusterService "global-ingress" and ingress-nginx (v4.11.0) defined in ClusterDeployment object will be deployed on the cluster.
 
 > NOTE: If servicesPriority are equal, the first one to reach the cluster wins and deploys its beach-head services.
 
 ## Checking Status
 
 The status for the MultiClusterService object will show the deployment status for the beach-head services managed
-by it on each of the CAPI target clusters that it matches. Consider the same example where 2 ManagedClusters
+by it on each of the CAPI target clusters that it matches. Consider the same example where 2 ClusterDeployments
 and 1 MultiClusterService is deployed.
 
 > EXAMPLE: Status for `global-ingress` MultiClusterService
@@ -206,10 +206,10 @@ and 1 MultiClusterService is deployed.
 The status under `.status.services` shows a conflict for `dev-cluster-2` as expected because the MultiClusterService has a lower priority.
 Whereas, it shows provisioned for `dev-cluster-1` because the MultiClusterService has a higher priority.
 
-> EXAMPLE: Status for `dev-cluster-1` ManagedCluster (only sections relevant to beach-head services):
+> EXAMPLE: Status for `dev-cluster-1` ClusterDeployment (only sections relevant to beach-head services):
 > ```yaml
 > apiVersion: hmc.mirantis.com/v1alpha1
-> kind: ManagedCluster
+> kind: ClusterDeployment
 > metadata:
 >   . . . 
 >   name: dev-cluster-1
@@ -252,13 +252,13 @@ Whereas, it shows provisioned for `dev-cluster-1` because the MultiClusterServic
 >       type: ingress-nginx.ingress-nginx/SveltosHelmReleaseReady
 > ```
 
-The status under `.status.services` for ManagedCluster `dev-cluster-1` shows that it is managing kyverno but unable to manage ingress-nginx because
+The status under `.status.services` for ClusterDeployment `dev-cluster-1` shows that it is managing kyverno but unable to manage ingress-nginx because
 another object with higher priority is managing it, so it shows a conflict instead.
 
-> EXAMPLE: Status for `dev-cluster-2` ManagedCluster (only sections relevant to beach-head services):
+> EXAMPLE: Status for `dev-cluster-2` ClusterDeployment (only sections relevant to beach-head services):
 > ```yaml
 > apiVersion: hmc.mirantis.com/v1alpha1
-> kind: ManagedCluster
+> kind: ClusterDeployment
 > metadata:
 >   . . .
 >   name: dev-cluster-2
@@ -292,8 +292,8 @@ another object with higher priority is managing it, so it shows a conflict inste
 >       type: ingress-nginx.ingress-nginx/SveltosHelmReleaseReady
 > ```
 
-The status under `.status.services` for ManagedCluster `dev-cluster-2` shows that it is managing ingress-nginx as expected since it has a higher priority.
+The status under `.status.services` for ClusterDeployment `dev-cluster-2` shows that it is managing ingress-nginx as expected since it has a higher priority.
 
 ## Parameter List
 
-Refer to "Parameter List" in [Deploy beach-head Services using Managed Cluster](./deploy-services-managedcluster.md).
+Refer to "Parameter List" in [Deploy beach-head Services using Managed Cluster](./deploy-services-clusterdeployment.md).

--- a/docs/usage/create-multiclusterservice.md
+++ b/docs/usage/create-multiclusterservice.md
@@ -83,7 +83,7 @@ dev-cluster-2                  Provisioned   3h10m             app.kubernetes.io
 >   . . .
 > ```
 
-> NOTE: See [Deploy beach-head Services using Managed Cluster](deploy-services-clusterdeployment.md) for how to use beach-head services with ClusterDeployment.
+> NOTE: See [Deploy beach-head Services using Cluster Deployment](deploy-services-clusterdeployment.md) for how to use beach-head services with ClusterDeployment.
 
 Now the following `global-ingress` MultiClusterService object is created with the following spec:
 
@@ -110,11 +110,11 @@ version 4.11.3 of ingress-nginx service on it.
 
 ### Configuring Custom Values
 
-Refer to "Configuring Custom Values" in [Deploy beach-head Services using Managed Cluster](./deploy-services-clusterdeployment.md).
+Refer to "Configuring Custom Values" in [Deploy beach-head Services using Cluster Deployment](./deploy-services-clusterdeployment.md).
 
 ### Templating Custom Values
 
-Refer to "Templating Custom Values" in [Deploy beach-head Services using Managed Cluster](./deploy-services-clusterdeployment.md).
+Refer to "Templating Custom Values" in [Deploy beach-head Services using Cluster Deployment](./deploy-services-clusterdeployment.md).
 
 ### Services Priority and Conflict
 
@@ -296,4 +296,4 @@ The status under `.status.services` for ClusterDeployment `dev-cluster-2` shows 
 
 ## Parameter List
 
-Refer to "Parameter List" in [Deploy beach-head Services using Managed Cluster](./deploy-services-clusterdeployment.md).
+Refer to "Parameter List" in [Deploy beach-head Services using Cluster Deployment](./deploy-services-clusterdeployment.md).

--- a/docs/usage/deploy-services-clusterdeployment.md
+++ b/docs/usage/deploy-services-clusterdeployment.md
@@ -2,14 +2,14 @@
 
 ## Deployment
 
-Beach-head services can be deployed on a managed cluster (i.e., target cluster) using the `ManagedCluster` object.
+Beach-head services can be deployed on a managed cluster (i.e., target cluster) using the `ClusterDeployment` object.
 Consider the following example:
 
-> EXAMPLE: `ManagedCluster` object for AWS Infrastructure Provider with beach-head services
+> EXAMPLE: `ClusterDeployment` object for AWS Infrastructure Provider with beach-head services
 > 
 > ```yaml
 > apiVersion: hmc.mirantis.com/v1alpha1
-> kind: ManagedCluster
+> kind: ClusterDeployment
 > metadata:
 >   name: my-managed-cluster
 >   namespace: hmc-system
@@ -68,7 +68,7 @@ In the example above the following fields are relevant to the deployment of beac
 > NOTE:
 > Refer to [Parameter List](#parameter-list) for more detail about these fields.
 
-This example `ManagedCluster` object will deploy kyverno and ingress-nginx referred to by their
+This example `ClusterDeployment` object will deploy kyverno and ingress-nginx referred to by their
 service templates respectively on the target cluster it is managing. See the example below for
 the service template for kyverno.
 
@@ -97,15 +97,15 @@ For more details see the [Bring your own Templates](../template/byo-templates.md
 
 ### Configuring Custom Values
 
-Helm values can be passed to each beach-head services with the `.spec.services[].values` field in the `ManagedCluster` or `MultiClusterService` object.
+Helm values can be passed to each beach-head services with the `.spec.services[].values` field in the `ClusterDeployment` or `MultiClusterService` object.
 
 EXAMPLE: 
 ```yaml
 apiVersion: hmc.mirantis.com/v1alpha1
-kind: ManagedCluster
+kind: ClusterDeployment
 metadata:
   . . .
-  name: my-managedcluster
+  name: my-clusterdeployment
   namespace: hmc-system
   . . .
 spec:
@@ -149,9 +149,9 @@ Using Sveltos templating feature, we can also write templates which can be usefu
 EXAMPLE:
 ```yaml
 apiVersion: hmc.mirantis.com/v1alpha1
-kind: ManagedCluster
+kind: ClusterDeployment
 metadata:
-  name: my-managedcluster
+  name: my-clusterdeployment
   namespace: hmc-system
 spec:
   . . .
@@ -168,16 +168,16 @@ spec:
         controlPlaneEndpointPort: "{{ .Cluster.spec.controlPlaneEndpoint.port }}"
 ```
 
-In the example above the host and port information is being fetched from the spec of the CAPI cluster that belongs to this `ManagedCluster`.
+In the example above the host and port information is being fetched from the spec of the CAPI cluster that belongs to this `ClusterDeployment`.
 
 ## Checking status
 
-The `.status.services` field of the `ManagedCluster` object shows the status for each of the beach-head services.
+The `.status.services` field of the `ClusterDeployment` object shows the status for each of the beach-head services.
 
-> EXAMPLE: Status for beach-head services deployed with `ManagedCluster`
+> EXAMPLE: Status for beach-head services deployed with `ClusterDeployment`
 > ```yaml
 > apiVersion: hmc.mirantis.com/v1alpha1
-> kind: ManagedCluster
+> kind: ClusterDeployment
 > metadata:
 >   . . .
 >   generation: 1
@@ -241,10 +241,10 @@ ingress-nginx-controller-cbcf8bf58-zhvph   1/1     Running   0          24m
 To remove a beach-head service simply remove its entry from `.spec.services`.
 The example below removes `kyverno-3-2-6` so its status also removed from `.status.services`.
 
-> EAMPLE: Showing removal of `kyverno-3-2-6` from `ManagedCluster`
+> EAMPLE: Showing removal of `kyverno-3-2-6` from `ClusterDeployment`
 > ```yaml
 > apiVersion: hmc.mirantis.com/v1alpha1
-> kind: ManagedCluster
+> kind: ClusterDeployment
 > metadata:
 >   . . .
 >   generation: 2

--- a/docs/usage/deploy-services-clusterdeployment.md
+++ b/docs/usage/deploy-services-clusterdeployment.md
@@ -1,8 +1,8 @@
-# Deploy beach-head Services using Managed Cluster
+# Deploy beach-head Services using Cluster Deployment
 
 ## Deployment
 
-Beach-head services can be deployed on a managed cluster (i.e., target cluster) using the `ClusterDeployment` object.
+Beach-head services can be installed on a cluster deployment (i.e., target cluster) using the `ClusterDeployment` object.
 Consider the following example:
 
 > EXAMPLE: `ClusterDeployment` object for AWS Infrastructure Provider with beach-head services
@@ -233,7 +233,7 @@ ingress-nginx-controller-cbcf8bf58-zhvph   1/1     Running   0          24m
 ```
 
 > NOTE:
-> * Refer to Step 7 of [Create Managed Cluster](../usage/create-managed-cluster.md/step-7-retrieve-kubernetes-configuration-of-your-managed-cluster) guide for how to access the target cluster.
+> * Refer to Step 7 of [Create Cluster Deployment](../usage/create-managed-cluster.md/step-7-retrieve-kubernetes-configuration-of-your-managed-cluster) guide for how to access the target cluster.
 > * Refer to [Service Templates](../servicetemplates.md) for more detail on what statuses are reported.
 
 ## Removing beach-head services

--- a/docs/usage/installation.md
+++ b/docs/usage/installation.md
@@ -77,7 +77,7 @@ how to perform 2A installation in the air-gapped environment.
 
 > WARNING: 
 > 
-> Make sure you have no Project 2A `ManagedCluster` objects left in the cluster prior to deletion.
+> Make sure you have no Project 2A `ClusterDeployment` objects left in the cluster prior to deletion.
 
 2. Remove the `hmc` Helm release:
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -77,7 +77,7 @@ nav:
   - Usage:
       - Installation Guide: usage/installation.md
       - Air-gapped Installation Guide: usage/airgap.md
-      - Create Managed Cluster: usage/create-managed-cluster.md
+      - Create Cluster Deployment: usage/create-cluster-deployment.md
       - Cluster Updates: usage/cluster-update.md
       - 2A Upgrade: usage/2a-upgrade.md
   - Templates:


### PR DESCRIPTION
This updates the docs to reflect the name change that will happen once https://github.com/Mirantis/hmc/pull/725 is merged.