### PR TITLE
Fix all HMC and Project 2A references

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,24 +1,24 @@
 # Architecture
 
 
-Below is a diagram that provides an overview of how Project 2A works.
+Below is a diagram that provides an overview of how k0rdent works.
 
 ## Architectural Overview
 
 ```mermaid
 ---
-title: HMC Overview
+title: kcm Overview
 ---
 erDiagram
-    USER ||--o{ HMC : uses
+    USER ||--o{ kcm : uses
     USER ||--o{ Template : assigns
-    Template ||--o{ HMC : "used by"
-    HMC ||--o{ CAPI : connects
+    Template ||--o{ kcm : "used by"
+    kcm ||--o{ CAPI : connects
     CAPI ||--|{ CAPV : provider
     CAPI ||--|{ CAPA : provider
     CAPI ||--|{ CAPZ : provider
     CAPI ||--|{ CAPO : provider
-    CAPI ||--|{ K0smotron : Bootstrap
+    CAPI ||--|{ k0smotron : Bootstrap
     K0smotron |o..o| CAPV : uses
     K0smotron |o..o| CAPA : uses
     K0smotron |o..o| CAPZ : uses

--- a/docs/clustertemplates/aws/hosted-control-plane.md
+++ b/docs/clustertemplates/aws/hosted-control-plane.md
@@ -4,7 +4,7 @@ This section covers setting up for a k0smotron hosted control plane on AWS.
 
 ## Prerequisites
 
--   Management Kubernetes cluster (v1.28+) deployed on AWS with HMC installed on it
+-   Management Kubernetes cluster (v1.28+) deployed on AWS with kcm installed on it
 -   Default storage class configured on the management cluster
 -   VPC ID for the worker nodes
 -   Subnet ID which will be used along with AZ information
@@ -21,11 +21,11 @@ reused with a management cluster.
 If you deployed your AWS Kubernetes cluster using Cluster API Provider AWS (CAPA)
 you can obtain all the necessary data with the commands below or use the
 template found below in the
-[HMC ClusterDeployment manifest generation](#hmc-clusterdeployment-manifest-generation)
+[kcm ClusterDeployment manifest generation](#kcm-clusterdeployment-manifest-generation)
 section.
 
 If using the `aws-standalone-cp` template to deploy a hosted cluster it is
-recommended to use a `t3.large` or larger instance type as the `hmc-controller`
+recommended to use a `t3.large` or larger instance type as the `kcm-controller`
 and other provider controllers will need a large amount of resources to run.
 
 **VPC ID**
@@ -62,7 +62,7 @@ clusters you should setup additional connectivity rules like
 [VPC peering](https://docs.aws.amazon.com/whitepapers/latest/building-scalable-secure-multi-vpc-network-infrastructure/vpc-peering.html).
 
 
-## HMC ClusterDeployment manifest
+## kcm ClusterDeployment manifest
 
 With all the collected data your `ClusterDeployment` manifest will look similar to this:
 
@@ -97,7 +97,7 @@ spec:
 > In this example we're using the `us-west-1` region, but you should use the
 > region of your VPC.
 
-## HMC ClusterDeployment manifest generation
+## kcm ClusterDeployment manifest generation
 
 Grab the following `ClusterDeployment` manifest template and save it to a file
 named `clusterdeployment.yaml.tpl`:
@@ -135,9 +135,9 @@ Then run the following command to create the `clusterdeployment.yaml`:
 kubectl get awscluster cluster -o go-template="$(cat clusterdeployment.yaml.tpl)" > clusterdeployment.yaml
 ```
 ## Deployment Tips
-* Ensure HMC templates and the controller image are somewhere public and
+* Ensure kcm templates and the controller image are somewhere public and
   fetchable.
-* For installing the HMC charts and templates from a custom repository, load
+* For installing the kcm charts and templates from a custom repository, load
   the `kubeconfig` from the cluster and run the commands:
 
 ```
@@ -149,7 +149,7 @@ KUBECONFIG=kubeconfig make dev-templates
   the command:
 
 ```
-KUBECONFIG=kubeconfig kubectl patch AWSCluster <hosted-cluster-name> --type=merge --subresource status --patch 'status: {ready: true}' -n hmc-system
+KUBECONFIG=kubeconfig kubectl patch AWSCluster <hosted-cluster-name> --type=merge --subresource status --patch 'status: {ready: true}' -n kcm-system
 ```
 
 For additional information on why this is required [click here](https://docs.k0smotron.io/stable/capi-aws/#:~:text=As%20we%20are%20using%20self%2Dmanaged%20infrastructure%20we%20need%20to%20manually%20mark%20the%20infrastructure%20ready.%20This%20can%20be%20accomplished%20using%20the%20following%20command).

--- a/docs/clustertemplates/aws/vpc-removal.md
+++ b/docs/clustertemplates/aws/vpc-removal.md
@@ -6,7 +6,7 @@ It is possible to deal with non-deleted VPCs the following ways:
 
 ## Applying ownership information on VPCs
 
-When VPCs have owner information, all AWS resources will be removed when 2A ESK cluster is deleted.
+When VPCs have owner information, all AWS resources will be removed when k0rdent EKS cluster is deleted.
 So, after provisioning EKS cluster the operator can go and set tags (i.e. `tag:Owner`) and it will be sufficient for CAPA to manage them.
 
 ## GuardDuty VPCE

--- a/docs/clustertemplates/azure/hosted-control-plane.md
+++ b/docs/clustertemplates/azure/hosted-control-plane.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 
--   Management Kubernetes cluster (v1.28+) deployed on Azure with HMC installed
+-   Management Kubernetes cluster (v1.28+) deployed on Azure with kcm installed
     on it
 -   Default storage class configured on the management cluster
 
@@ -63,7 +63,7 @@ kubectl get azurecluster <cluster-name> -o go-template='{{(index .spec.networkSp
 
 
 
-## HMC ClusterDeployment manifest
+## kcm ClusterDeployment manifest
 
 With all the collected data your `ClusterDeployment` manifest will look similar to this:
 

--- a/docs/clustertemplates/openstack/template-parameters.md
+++ b/docs/clustertemplates/openstack/template-parameters.md
@@ -40,7 +40,7 @@ apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ClusterDeployment
 metadata:
   name: my-openstack-cluster-deployment
-  namespace: hmc-system
+  namespace: kcm-system
 spec:
   template: openstack-standalone-cp-0-0-1
   credential: openstack-cluster-identity-cred

--- a/docs/clustertemplates/vsphere/hosted-control-plane.md
+++ b/docs/clustertemplates/vsphere/hosted-control-plane.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 
-- Management Kubernetes cluster (v1.28+) deployed on vSphere with HMC installed
+- Management Kubernetes cluster (v1.28+) deployed on vSphere with kcm installed
   on it
 
 Keep in mind that all control plane components for all managed clusters will

--- a/docs/credential/distribution.md
+++ b/docs/credential/distribution.md
@@ -8,7 +8,7 @@ Each access rule specifies:
 1. The target namespaces where credentials should be delivered.
 2. A list of `Credential` names to distribute to those namespaces.
 
-The HMC controller will copy the specified `Credential` objects from the **system** namespace to the target
+The kcm controller will copy the specified `Credential` objects from the **system** namespace to the target
 namespaces based on the `accessRules` in the `AccessManagement` spec.
 
 > INFO:

--- a/docs/credential/main.md
+++ b/docs/credential/main.md
@@ -49,11 +49,11 @@ spec:
     apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: AzureClusterIdentity
     name: azure-cluster-identity
-    namespace: hmc-system
+    namespace: kcm-system
 ```
 
 In the example above `Credential` object is referencing `AzureClusterIdentity`
-which was created in the `hmc-system` namespace.
+which was created in the `kcm-system` namespace.
 
 The `.spec.description` field can be used to provide arbitrary description of the
 object, so user could make a decision which credentials to use if several are
@@ -121,8 +121,8 @@ In k0rdent these Secrets aren't used and will not be added to the
 #### OpenStack
 
 For OpenStack, CAPO relies on a clouds.yaml file.
-In Project 2A, you provide this file in a Kubernetes Secret that references OpenStack credentials
-(ideally application credentials for enhanced security). During reconciliation, HMC
+In k0rdent, you provide this file in a Kubernetes Secret that references OpenStack credentials
+(ideally application credentials for enhanced security). During reconciliation, kcm
 automatically generates the cloud-config required by OpenStack’s cloud-controller-manager.
 
 For more details, refer to the [kcm OpenStack Credential Propagation doc](https://github.com/k0rdent/kcm/blob/main/docs/dev.md#openstack).

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -80,7 +80,7 @@ resource (CR) that defines the infrastructure-specific configuration needed for 
 Kubernetes clusters. It enables Cluster API (CAPI) to provision and manage clusters on 
 a specific infrastructure platform (e.g., AWS, Azure, VMware, OpenStack, etc.).
 
-### Mutli Cluster Service
+### Multi-Cluster Service
 The `MultiClusterService` is a custom resource used to manage deployment of beach-head 
 services across multiple clusters.
 

--- a/docs/quick-start/aws.md
+++ b/docs/quick-start/aws.md
@@ -74,7 +74,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: aws-cluster-identity-secret
-  namespace: hmc-system
+  namespace: kcm-system
 type: Opaque
 stringData:
   AccessKeyID: AKIAQF+EXAMPLE
@@ -90,7 +90,7 @@ kubectl apply -f aws-cluster-identity-secret.yaml
 > WARNING:
 > 
 > The secret must be created in the same `Namespace` where the CAPA provider is
-> running. In case of k0rdent it's currently `hmc-system`. Placing secret in
+> running. In case of k0rdent it's currently `kcm-system`. Placing secret in
 > any other `Namespace` will result in the controller not able to read it.
 
 ## Step 3: Create AWSClusterStaticIdentity Object
@@ -137,7 +137,7 @@ apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: Credential
 metadata:
   name: aws-cluster-identity-cred
-  namespace: hmc-system
+  namespace: kcm-system
 spec:
   description: "Credential Example"
   identityRef:
@@ -164,7 +164,7 @@ apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ClusterDeployment
 metadata:
   name: my-aws-clusterdeployment1
-  namespace: hmc-system
+  namespace: kcm-system
 spec:
   template: aws-standalone-cp-0-0-4
   credential: aws-cluster-identity-cred
@@ -186,13 +186,13 @@ There will be a delay as the cluster finishes provisioning. Follow the
 provisioning process with the following command:
 
 ```bash
-kubectl -n hmc-system get clusterdeployment.k0rdent.mirantis.com my-aws-clusterdeployment1 --watch
+kubectl -n kcm-system get clusterdeployment.k0rdent.mirantis.com my-aws-clusterdeployment1 --watch
 ```
 
 After the cluster is `Ready`, you can access it via the kubeconfig, like this:
 
 ```bash
-kubectl -n hmc-system get secret my-aws-clusterdeployment1-kubeconfig -o jsonpath='{.data.value}' | base64 -d > my-aws-clusterdeployment1-kubeconfig.kubeconfig
+kubectl -n kcm-system get secret my-aws-clusterdeployment1-kubeconfig -o jsonpath='{.data.value}' | base64 -d > my-aws-clusterdeployment1-kubeconfig.kubeconfig
 ```
 
 ```bash

--- a/docs/quick-start/azure.md
+++ b/docs/quick-start/azure.md
@@ -105,7 +105,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: azure-cluster-identity-secret
-  namespace: hmc-system
+  namespace: kcm-system
 stringData:
   clientSecret: <password> # Password retrieved from the Service Principal
 type: Opaque
@@ -135,13 +135,13 @@ metadata:
   labels:
     clusterctl.cluster.x-k8s.io/move-hierarchy: "true"
   name: azure-cluster-identity
-  namespace: hmc-system
+  namespace: kcm-system
 spec:
   allowedNamespaces: {}
   clientID: <appId> # The App ID retrieved from the Service Principal above in Step 2
   clientSecret:
     name: azure-cluster-identity-secret
-    namespace: hmc-system
+    namespace: kcm-system
   tenantID: <tenant> # The Tenant ID retrieved from the Service Principal above in Step 2
   type: ServicePrincipal
 ```
@@ -167,13 +167,13 @@ apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: Credential
 metadata:
   name: azure-cluster-identity-cred
-  namespace: hmc-system
+  namespace: kcm-system
 spec:
   identityRef:
     apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: AzureClusterIdentity
     name: azure-cluster-identity
-    namespace: hmc-system
+    namespace: kcm-system
 ```
 
 Apply the YAML to your cluster:
@@ -196,7 +196,7 @@ apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ClusterDeployment
 metadata:
   name: my-azure-clusterdeployment1
-  namespace: hmc-system
+  namespace: kcm-system
 spec:
   template: azure-standalone-cp-0-0-3
   credential: azure-cluster-identity-cred
@@ -219,13 +219,13 @@ There will be a delay as the cluster finishes provisioning. Follow the
 provisioning process with the following command:
 
 ```shell
-kubectl -n hmc-system get clusterdeployment.k0rdent.mirantis.com my-azure-clusterdeployment1 --watch
+kubectl -n kcm-system get clusterdeployment.k0rdent.mirantis.com my-azure-clusterdeployment1 --watch
 ```
 
 After the cluster is `Ready`, you can access it via the kubeconfig, like this:
 
 ```shell
-kubectl -n hmc-system get secret my-azure-clusterdeployment1-kubeconfig -o jsonpath='{.data.value}' | base64 -d > my-azure-clusterdeployment1-kubeconfig.kubeconfig
+kubectl -n kcm-system get secret my-azure-clusterdeployment1-kubeconfig -o jsonpath='{.data.value}' | base64 -d > my-azure-clusterdeployment1-kubeconfig.kubeconfig
 ```
 
 ```shell

--- a/docs/quick-start/installation.md
+++ b/docs/quick-start/installation.md
@@ -23,7 +23,7 @@ It may be helpful to have the following tools installed:
 ## Installation via Helm
 
 ```bash
-helm install hmc oci://ghcr.io/k0rdent/kcm/charts/hmc --version 0.0.6 -n hmc-system --create-namespace
+helm install kcm oci://ghcr.io/k0rdent/kcm/charts/kcm --version 0.0.7 -n kcm-system --create-namespace
 ```
 
 ## Verification
@@ -33,10 +33,10 @@ fully installed and configured.
 
 ### Verify Core Components are running
 
-Check pods are running in the `hmc-system` namespace with the following command:
+Check pods are running in the `kcm-system` namespace with the following command:
 
 ```bash
-kubectl get pods -n hmc-system
+kubectl get pods -n kcm-system
 ```
 
 The output should be similar to:
@@ -48,11 +48,11 @@ capi-controller-manager-6bc5fc5f88-hd8pv                       1/1     Running
 capv-controller-manager-bb5ff9bd5-7dsr9                        1/1     Running
 capz-controller-manager-5dd988768-qjdbl                        1/1     Running
 helm-controller-76f675f6b7-4d47l                               1/1     Running
-hmc-cert-manager-7c8bd964b4-nhxnq                              1/1     Running
-hmc-cert-manager-cainjector-56476c46f9-xvqhh                   1/1     Running
-hmc-cert-manager-webhook-69d7fccf68-s46w8                      1/1     Running
-hmc-cluster-api-operator-79459d8575-2s9jc                      1/1     Running
-hmc-controller-manager-64869d9f9d-zktgw                        1/1     Running
+kcm-cert-manager-7c8bd964b4-nhxnq                              1/1     Running
+kcm-cert-manager-cainjector-56476c46f9-xvqhh                   1/1     Running
+kcm-cert-manager-webhook-69d7fccf68-s46w8                      1/1     Running
+kcm-cluster-api-operator-79459d8575-2s9jc                      1/1     Running
+kcm-controller-manager-64869d9f9d-zktgw                        1/1     Running
 k0smotron-controller-manager-bootstrap-6c5f6c7884-d2fqs        2/2     Running
 k0smotron-controller-manager-control-plane-857b8bffd4-zxkx2    2/2     Running
 k0smotron-controller-manager-infrastructure-7f77f55675-tv8vb   2/2     Running
@@ -88,7 +88,7 @@ been installed and are valid.
 Check `ProviderTemplate` objects with:
 
 ```sh
-kubectl get providertemplate -n hmc-system
+kubectl get providertemplate -n kcm-system
 ```
 
 The output should be similar to:
@@ -99,7 +99,7 @@ cluster-api-X-Y-Z                    true
 cluster-api-provider-aws-X-Y-Z       true
 cluster-api-provider-azure-X-Y-Z     true
 cluster-api-provider-vsphere-X-Y-Z   true
-hmc-X-Y-Z                            true
+kcm-X-Y-Z                            true
 k0smotron-X-Y-Z                      true
 projectsveltos-X-Y-Z                 true
 ```
@@ -107,7 +107,7 @@ projectsveltos-X-Y-Z                 true
 Check `ClusterTemplate` objects with:
 
 ```bash
-kubectl get clustertemplate -n hmc-system
+kubectl get clustertemplate -n kcm-system
 ```
 
 The output should be similar to:
@@ -126,7 +126,7 @@ vsphere-standalone-cp-X-Y-Z         true
 Check `ServiceTemplate` objects with:
 
 ```sh
-kubectl get servicetemplate -n hmc-system
+kubectl get servicetemplate -n kcm-system
 ```
 
 The output should be similar to:

--- a/docs/quick-start/openstack.md
+++ b/docs/quick-start/openstack.md
@@ -8,7 +8,7 @@ To better understand how k0rdent uses credentials, read the
 
 ### k0rdent Management Cluster
 
-You need a Kubernetes cluster with [k0rdent installed](installation.md).
+You need a Kubernetes cluster with [kcm installed](installation.md).
 
 ### Software prerequisites
 
@@ -28,7 +28,8 @@ This credential should include:
 - OS_IDENTITY_API_VERSION (commonly 3)
 - OS_AUTH_TYPE (e.g., v3applicationcredential)
 
-> Note: Using an Application Credential is strongly recommended because it limits scope and improves security over a raw username/password approach.
+> NOTE:
+> Using an Application Credential is strongly recommended because it limits scope and improves security over a raw username/password approach.
 
 ## Step 2: Create the OpenStack Credentials Secret on k0rdent Management Cluster
 
@@ -39,7 +40,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: openstack-cloud-config
-  namespace: hmc-system
+  namespace: kcm-system
 stringData:
   clouds.yaml: |
     clouds:
@@ -70,14 +71,14 @@ apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: Credential
 metadata:
   name: openstack-cluster-identity-cred
-  namespace: hmc-system
+  namespace: kcm-system
 spec:
   description: "OpenStack credentials"
   identityRef:
     apiVersion: v1
     kind: Secret
     name: openstack-cloud-config
-    namespace: hmc-system
+    namespace: kcm-system
 ```
 
 Apply the YAML to your cluster:
@@ -89,7 +90,7 @@ kubectl apply -f openstack-cluster-identity-cred.yaml
 > NOTE:
 > 1. .spec.identityRef.kind hould be Secret.
 > 2. .spec.identityRef.name must match the Secret you created in Step 2.
-> 3. .spec.identityRef.namespace must be the same as the Secret’s namespace (hmc-system).
+> 3. .spec.identityRef.namespace must be the same as the Secret’s namespace (kcm-system).
 
 ## Step 4: Create Your First Managed Cluster
 
@@ -103,7 +104,7 @@ apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ClusterDeployment
 metadata:
   name: my-openstack-cluster-deployment
-  namespace: hmc-system
+  namespace: kcm-system
 spec:
   template: openstack-standalone-cp-0-0-1
   credential: openstack-cluster-identity-cred
@@ -138,13 +139,13 @@ There will be a delay as the cluster finishes provisioning. Follow the
 provisioning process with the following command:
 
 ```bash
-kubectl -n hmc-system get clusterdeployment.k0rdent.mirantis.com my-openstack-cluster-deployment --watch
+kubectl -n kcm-system get clusterdeployment.k0rdent.mirantis.com my-openstack-cluster-deployment --watch
 ```
 
 After the cluster is `Ready`, you can access it via the kubeconfig, like this:
 
 ```bash
-kubectl -n hmc-system get secret my-openstack-cluster-deployment-kubeconfig -o jsonpath='{.data.value>' | base64 -d > my-openstack-cluster-deployment-kubeconfig.kubeconfig
+kubectl -n kcm-system get secret my-openstack-cluster-deployment-kubeconfig -o jsonpath='{.data.value>' | base64 -d > my-openstack-cluster-deployment-kubeconfig.kubeconfig
 ```
 
 ```bash

--- a/docs/quick-start/vsphere.md
+++ b/docs/quick-start/vsphere.md
@@ -69,7 +69,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: vsphere-cluster-identity-secret
-  namespace: hmc-system
+  namespace: kcm-system
 stringData:
   username: <user>
   password: <password>
@@ -116,7 +116,7 @@ apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: Credential
 metadata:
   name: vsphere-cluster-identity-cred
-  namespace: hmc-system
+  namespace: kcm-system
 spec:
   identityRef:
     apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
@@ -148,7 +148,7 @@ apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ClusterDeployment
 metadata:
   name: my-vsphere-clusterdeployment1
-  namespace: hmc-system
+  namespace: kcm-system
 spec:
   template: vsphere-standalone-cp-0-0-3
   credential: vsphere-cluster-identity-cred
@@ -190,13 +190,13 @@ There will be a delay as the cluster finishes provisioning. Follow the
 provisioning process with the following command:
 
 ```shell
-kubectl -n hmc-system get clusterdeployment.k0rdent.mirantis.com my-vsphere-clusterdeployment1 --watch
+kubectl -n kcm-system get clusterdeployment.k0rdent.mirantis.com my-vsphere-clusterdeployment1 --watch
 ```
 
 After the cluster is `Ready`, you can access it via the kubeconfig, like this:
 
 ```shell
-kubectl -n hmc-system get secret my-vsphere-clusterdeployment1-kubeconfig -o jsonpath='{.data.value}' | base64 -d > my-vsphere-clusterdeployment1-kubeconfig.kubeconfig
+kubectl -n kcm-system get secret my-vsphere-clusterdeployment1-kubeconfig -o jsonpath='{.data.value}' | base64 -d > my-vsphere-clusterdeployment1-kubeconfig.kubeconfig
 ```
 
 ```shell

--- a/docs/rbac/roles.md
+++ b/docs/rbac/roles.md
@@ -1,17 +1,17 @@
-# 2A Role-Based Access Control
+# k0rdent Role-Based Access Control
 
-2A leverages the Kubernetes RBAC system and provides a set of standard `ClusterRoles` with
-associated permissions. All `ClusterRoles` are created as part of the HMC helm chart.
-2A roles are based on labels and aggregated permissions, meaning they automatically collect
+k0rdent leverages the Kubernetes RBAC system and provides a set of standard `ClusterRoles` with
+associated permissions. All `ClusterRoles` are created as part of the kcm helm chart.
+k0rdent roles are based on labels and aggregated permissions, meaning they automatically collect
 rules from other `ClusterRoles` with specific labels.
 
-The following table outlines the roles available in 2A, along with their respective read/write or read-only
+The following table outlines the roles available in k0rdent, along with their respective read/write or read-only
 permissions:
 
 | Roles                            | Global Admin | Global Viewer | Namespace Admin | Namespace Editor | Namespace Viewer |
 |----------------------------------|--------------|---------------|-----------------|------------------|------------------|
 | **Scope**                        | **Global**   | **Global**    | **Namespace**   | **Namespace**    | **Namespace**    |
-| 2A management                    | r/w          | r/o           | -               | -                | -                |
+| k0rdent management               | r/w          | r/o           | -               | -                | -                |
 | Namespaces management            | r/w          | r/o           | -               | -                | -                |
 | Provider Templates               | r/w          | r/o           | -               | -                | -                |
 | Global Template Management       | r/w          | r/o           | -               | -                | -                |
@@ -25,17 +25,17 @@ permissions:
 
 ## Roles definition
 
-This section provides an overview of all `ClusterRoles` available in 2A.
+This section provides an overview of all `ClusterRoles` available in k0rdent.
 
 > NOTE:
-> The names of the `ClusterRoles` may have different prefix depending on the name of the HMC Helm chart.
-> The `ClusterRoles` definitions below use the `hmc` prefix, which is the default name of the HMC Helm chart.
+> The names of the `ClusterRoles` may have different prefix depending on the name of the kcm Helm chart.
+> The `ClusterRoles` definitions below use the `kcm` prefix, which is the default name of the kcm Helm chart.
 
 ### Global Admin
 
-The `Global Admin` role provides full administrative access across all the 2A system.
+The `Global Admin` role provides full administrative access across all the k0rdent system.
 
-**Name**: `hmc-global-admin-role`
+**Name**: `kcm-global-admin-role`
 
 **Aggregation Rule**: Includes all `ClusterRoles` with the labels:
 
@@ -45,7 +45,7 @@ The `Global Admin` role provides full administrative access across all the 2A sy
 
 **Permissions**:
 
-1. Full access to 2A API
+1. Full access to k0rdent API
 2. Full access to Flux Helm repositories and Helm charts
 3. Full access to Cluster API identities
 4. Full access to namespaces and secrets
@@ -54,7 +54,7 @@ The `Global Admin` role provides full administrative access across all the 2A sy
 
 A user with the `Global Admin` role is authorized to perform the following actions:
 
-1. Manage the 2A configuration
+1. Manage the k0rdent configuration
 2. Manage namespaces in the management cluster
 3. Manage `Provider Templates`: add new templates or remove unneeded ones
 4. Manage `Cluster` and `Service Templates` in any namespace, including adding and removing templates
@@ -65,16 +65,16 @@ A user with the `Global Admin` role is authorized to perform the following actio
 8. Manage and deploy Services across multiple clusters in any namespace by modifying `MultiClusterService` resources
 9. Manage `ClusterDeployments` in any namespace
 10. Manage `Credentials` and `secrets` in any namespace
-11. Upgrade 2A
-12. Uninstall 2A
+11. Upgrade k0rdent
+12. Uninstall k0rdent
 
 
 ### Global Viewer
 
-The `Global Viewer` role grants read-only access across the 2A system. It does not permit any modifications,
+The `Global Viewer` role grants read-only access across the k0rdent system. It does not permit any modifications,
 including the creation of clusters.
 
-**Name**: `hmc-global-viewer-role`
+**Name**: `kcm-global-viewer-role`
 
 **Aggregation Rule**: Includes all `ClusterRoles` with the labels:
 
@@ -83,7 +83,7 @@ including the creation of clusters.
 
 **Permissions**:
 
-1. Read access to 2A API
+1. Read access to k0rdent API
 2. Read access to Flux Helm repositories and Helm charts
 3. Read access to Cluster API identities
 4. Read access to namespaces and secrets
@@ -92,7 +92,7 @@ including the creation of clusters.
 
 A user with the `Global Viewer` role is authorized to perform the following actions:
 
-1. View the 2A configuration
+1. View the k0rdent configuration
 2. List namespaces available in the management cluster
 3. List and get the detailed information about available `Provider Templates`
 4. List available `Cluster` and `Service Templates` in any namespace
@@ -107,7 +107,7 @@ A user with the `Global Viewer` role is authorized to perform the following acti
 
 The `Namespace Admin` role provides full administrative access within namespace.
 
-**Name**: `hmc-namespace-admin-role`
+**Name**: `kcm-namespace-admin-role`
 
 **Aggregation Rule**: Includes all `ClusterRoles` with the labels:
 
@@ -136,7 +136,7 @@ A user with the `Namespace Admin` role is authorized to perform the following ac
 The `Namespace Editor` role allows users to create and modify `ClusterDeployments` within namespace using predefined
 `Credentials` and `Templates`.
 
-**Name**: `hmc-namespace-editor-role`
+**Name**: `kcm-namespace-editor-role`
 
 **Aggregation Rule**: Includes all `ClusterRoles` with the labels:
 
@@ -163,7 +163,7 @@ A user with the `Namespace Editor` role has the following permissions in the nam
 
 The `Namespace Viewer` role grants read-only access to resources within a namespace.
 
-**Name**: `hmc-namespace-viewer-role`
+**Name**: `kcm-namespace-viewer-role`
 
 **Aggregation Rule**: Includes all `ClusterRoles` with the labels:
 

--- a/docs/template/byo-templates.md
+++ b/docs/template/byo-templates.md
@@ -1,6 +1,6 @@
 # Bring your own Templates
 
-This guide outlines the steps to bring your own Template to HMC.
+This guide outlines the steps to bring your own Template to kcm.
 
 ## Create a Source Object
 
@@ -15,7 +15,7 @@ A source object defines where the Helm chart is stored. The source can be one of
 > NOTES:
 > 1. The source object must exist in the same namespace as the Template.
 > 2. For cluster-scoped `ProviderTemplates`, the referenced source must reside in the **system** namespace
-> (default: `hmc-system`).
+> (default: `kcm-system`).
 
 ### Example: Custom Source Object with HelmRepository Kind
 
@@ -24,7 +24,7 @@ apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: custom-templates-repo
-  namespace: hmc-system
+  namespace: kcm-system
 spec:
   insecure: true
   interval: 10m0s
@@ -69,8 +69,8 @@ The controller will automatically create the `HelmChart` object based on the cha
 > NOTE:
 > `ClusterTemplate` and `ServiceTemplate` objects should reside in the same namespace as the `ClusterDeployment`
 > referencing them. The `ClusterDeployment` can't reference the Template from another namespace (the creation request will
-> be declined by the admission webhook). All `ClusterTemplates` and `ServiceTemplates` shipped with HMC reside in the
-> system namespace (defaults to `hmc-system`). To get the instructions on how to distribute Templates along multiple
+> be declined by the admission webhook). All `ClusterTemplates` and `ServiceTemplates` shipped with kcm reside in the
+> system namespace (defaults to `kcm-system`). To get the instructions on how to distribute Templates along multiple
 > namespaces, read [Template Life Cycle Management](main.md#template-life-cycle-management).
 
 ### Example: Custom ClusterTemplate with the Chart Definition to Create a new HelmChart
@@ -80,7 +80,7 @@ apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ClusterTemplate
 metadata:
   name: custom-template
-  namespace: hmc-system
+  namespace: kcm-system
 spec:
   providers:
     - bootstrap-k0smotron
@@ -101,7 +101,7 @@ apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ClusterTemplate
 metadata:
   name: custom-template
-  namespace: hmc-system
+  namespace: kcm-system
 spec:
   helm:
     chartRef:
@@ -259,15 +259,15 @@ is not listed in the core `CAPI` `ProviderTemplate` object, the updates to the `
 * if a `ClusterTemplate` object's exact kubernetes version does not satisfy the kubernetes version
 constraint from the related `ServiceTemplate` object, the updates to the `ClusterDeployment` object will be blocked.
 
-## Remove Templates shipped with HMC
+## Remove Templates shipped with kcm
 
-If you need to limit the templates that exist in your HMC installation, follow the instructions below:
+If you need to limit the templates that exist in your kcm installation, follow the instructions below:
 
-1. Get the list of `ProviderTemplates`, `ClusterTemplates` or `ServiceTemplates` shipped with HMC. For example,
+1. Get the list of `ProviderTemplates`, `ClusterTemplates` or `ServiceTemplates` shipped with kcm. For example,
 for `ClusterTemplate` objects, run:
 
     ```bash
-    kubectl get clustertemplates -n hmc-system -l helm.toolkit.fluxcd.io/name=hmc-templates
+    kubectl get clustertemplates -n kcm-system -l helm.toolkit.fluxcd.io/name=kcm-templates
     ```
 
     Example output:
@@ -281,5 +281,5 @@ for `ClusterTemplate` objects, run:
 2. Remove the template from the list using `kubectl delete`. For example:
 
     ```bash
-    kubectl delete clustertemplate -n hmc-system <template-name>
+    kubectl delete clustertemplate -n kcm-system <template-name>
     ```

--- a/docs/template/main.md
+++ b/docs/template/main.md
@@ -1,6 +1,6 @@
 # Templates system
 
-By default, 2A delivers a set of default `ProviderTemplate`, `ClusterTemplate` and `ServiceTemplate` objects:
+By default, k0rdent delivers a set of default `ProviderTemplate`, `ClusterTemplate` and `ServiceTemplate` objects:
 
 * `ProviderTemplate`
    The template containing the configuration of the provider (e.g., k0smotron). Cluster-scoped.
@@ -10,7 +10,7 @@ By default, 2A delivers a set of default `ProviderTemplate`, `ClusterTemplate` a
    The template containing the configuration of the service to be installed on the cluster deployment. Namespace-scoped.
 
 All Templates are immutable. You can also build your own templates and use them for deployment along with the
-templates shipped with 2A.
+templates shipped with k0rdent.
 
 ## Template Naming Convention
 
@@ -30,7 +30,7 @@ The templates can have any name. However, since they are immutable, we have adop
 >       reconcileStrategy: ChartVersion
 >       sourceRef:
 >         kind: HelmRepository
->         name: hmc-templates
+>         name: kcm-templates
 >       version: 0.0.4
 > status:
 >   capiContracts:
@@ -40,7 +40,7 @@ The templates can have any name. However, since they are immutable, we have adop
 >   chartRef:
 >     kind: HelmChart
 >     name: cluster-api-0-0-4
->     namespace: hmc-system
+>     namespace: kcm-system
 >   config:
 >     airgap: false
 >     config: {}
@@ -59,7 +59,7 @@ The templates can have any name. However, since they are immutable, we have adop
 > kind: ClusterTemplate
 > metadata:
 >   name: aws-standalone-cp-0-0-3
->   namespace: hmc-system
+>   namespace: kcm-system
 > spec:
 >   helm:
 >     chartSpec:
@@ -68,13 +68,13 @@ The templates can have any name. However, since they are immutable, we have adop
 >       reconcileStrategy: ChartVersion
 >       sourceRef:
 >         kind: HelmRepository
->         name: hmc-templates
+>         name: kcm-templates
 >       version: 0.0.3
 > status:
 >   chartRef:
 >     kind: HelmChart
 >     name: aws-standalone-cp-0-0-3
->     namespace: hmc-system
+>     namespace: kcm-system
 >   config:
 >     bastion:
 >       allowedCIDRBlocks: []
@@ -120,7 +120,7 @@ The templates can have any name. However, since they are immutable, we have adop
 >       instanceType: ""
 >       rootVolumeSize: 8
 >     workersNumber: 2
->   description: 'An HMC template to deploy a k0s cluster on AWS with bootstrapped control
+>   description: 'An kcm template to deploy a k0s cluster on AWS with bootstrapped control
 >     plane nodes. '
 >   observedGeneration: 1
 >   providerContracts:
@@ -140,7 +140,7 @@ The templates can have any name. However, since they are immutable, we have adop
 > kind: ServiceTemplate
 > metadata:
 >   name: kyverno-3-2-6
->   namespace: hmc-system
+>   namespace: kcm-system
 > spec:
 >   helm:
 >     chartSpec:
@@ -149,13 +149,13 @@ The templates can have any name. However, since they are immutable, we have adop
 >       reconcileStrategy: ChartVersion
 >       sourceRef:
 >         kind: HelmRepository
->         name: hmc-templates
+>         name: kcm-templates
 >       version: 3.2.6
 > status:
 >   chartRef:
 >     kind: HelmChart
 >     name: kyverno-3-2-6
->     namespace: hmc-system
+>     namespace: kcm-system
 >   description: A Helm chart to refer the official kyverno helm chart
 >   observedGeneration: 1
 >   valid: true
@@ -171,7 +171,7 @@ and the upgrade sequences for them.
 
 The example of the Cluster Template Management:
 
-1. Create `ClusterTemplateChain` object in the system namespace (defaults to `hmc-system`). Properly configure
+1. Create `ClusterTemplateChain` object in the system namespace (defaults to `kcm-system`). Properly configure
    the list of `.spec.supportedTemplates[].availableUpgrades` for the specified `ClusterTemplate` if the upgrade is allowed. For example:
 
 ```yaml
@@ -179,7 +179,7 @@ apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ClusterTemplateChain
 metadata:
   name: aws
-  namespace: hmc-system
+  namespace: kcm-system
 spec:
   supportedTemplates:
     - name: aws-standalone-cp-0-0-1
@@ -202,7 +202,7 @@ spec:
       - aws
 ```
 
-The HMC controllers will deliver all the `ClusterTemplate` objects across the target namespaces.
+The kcm controllers will deliver all the `ClusterTemplate` objects across the target namespaces.
 As a result, the new objects should be created:
 
 * `ClusterTemplateChain` `default/aws`

--- a/docs/template/pre-defined-service-templates.md
+++ b/docs/template/pre-defined-service-templates.md
@@ -1,10 +1,10 @@
 # Pre-defined ServiceTemplates
 
-HMC comes with a set of pre-defined ServiceTemplates. These templates are referring to the following Helm charts:
+kcm comes with a set of pre-defined ServiceTemplates. These templates are referring to the following Helm charts:
 
 > NOTE:
 > Listed Helm charts will be looked up in the registry configured by the `--default-registry-url`
-> flag provided to the `hmc-controller-manager` (default value: `oci://ghcr.io/k0rdent/kcm/charts`).
+> flag provided to the `kcm-controller-manager` (default value: `oci://ghcr.io/k0rdent/kcm/charts`).
 > In case of using different registry, the corresponding Helm charts must be available
 > in the registry in prior to using the ServiceTemplate.
 

--- a/docs/usage/adopt-existing-cluster.md
+++ b/docs/usage/adopt-existing-cluster.md
@@ -5,7 +5,7 @@
 In order to adopt an existing Kubernetes cluster you will require the following:
 
 - A kubernetes kubeconfig file for the cluster to be adopted
-- A management cluster with K0rdent installed
+- A management cluster with kcm installed
 - Network connectivity between the management cluster and the cluster to be adopted
 
 ## Installation
@@ -29,7 +29,7 @@ Create a `Credential` object with all credentials required per the
     kind: ClusterDeployment
     metadata:
       name: <cluster-name>
-      namespace: <hmc-system-namespace>
+      namespace: <kcm-system-namespace>
     spec:
       template: adopted-cluster-<template-version>
       credential: <credential-name>
@@ -53,7 +53,7 @@ Following is an interpolated example.
 > kind: ClusterDeployment
 > metadata:
 >   name: my-cluster
->   namespace: hmc-system
+>   namespace: kcm-system
 > spec:
 >   template: adotped-cluster-0-0-1
 >   credential: my-cluster-credential
@@ -63,7 +63,7 @@ Following is an interpolated example.
 
 ### Step 4: Apply the `ClusterDeployment` Configuration to Create it
 
-- Apply the `ClusterDeployment` object to your Project 2A deployment:
+- Apply the `ClusterDeployment` object to your k0rdent deployment:
 
   ```shell
   kubectl apply -f clusterdeployment.yaml
@@ -74,5 +74,5 @@ Following is an interpolated example.
 - Check the status of the newly created `ClusterDeployment`:
 
   ```shell
-  kubectl -n <namespace> get clusterdeployment.hmc <cluster-name> -o=yaml
+  kubectl -n <namespace> get clusterdeployment.kcm <cluster-name> -o=yaml
   ```

--- a/docs/usage/airgap.md
+++ b/docs/usage/airgap.md
@@ -6,7 +6,7 @@
 
 ## Prerequisites
 
-In order to install HMC in an air-gapped environment, you need will need the
+In order to install kcm in an air-gapped environment, you need will need the
 following:
 
 - An installed k0s cluster that will be used as the management cluster.  If you
@@ -15,9 +15,9 @@ following:
   implements an OCI image bundle watcher which allows k0s to utilize a bundle
   of management cluster images easily. Any Kubernetes distribution can be
   used, but instructions for using k0s are provided here.
-- The `KUBECONFIG` of a management cluster that will be the target for the HMC
+- The `KUBECONFIG` of a management cluster that will be the target for the kcm
   installation.
-- A registry that is accessible from the airgapped hosts to store the HMC images.
+- A registry that is accessible from the airgapped hosts to store the kcm images.
   If you do not have a registry you can deploy a [local Docker registry](https://distribution.github.io/distribution/)
   or use [mindthegap](https://github.com/mesosphere/mindthegap?tab=readme-ov-file#serving-a-bundle-supports-both-image-or-helm-chart)
 
@@ -31,8 +31,8 @@ following:
     > }
     > ```
 
-- A registry and associated chart repository for hosting HMC charts.  At this
-  time all HMC charts MUST be hosted in a single OCI chart repository.  See
+- A registry and associated chart repository for hosting kcm charts.  At this
+  time all kcm charts MUST be hosted in a single OCI chart repository.  See
   [Use OCI-based registries](https://helm.sh/docs/topics/registries/) in the
   Helm documentation for more information.
 - [jq](https://jqlang.github.io/jq/download/), Helm and Docker binaries
@@ -41,16 +41,16 @@ following:
 
 ## Installation
 
-1. Download the HMC airgap bundle, the bundle contains the
+1. Download the kcm airgap bundle, the bundle contains the
 following:
 
-    - `images/hmc-images-<version>.tgz` - The image bundle tarball for the
+    - `images/kcm-images-<version>.tgz` - The image bundle tarball for the
       management cluster, this bundle will be loaded into the management
       cluster.
-    - `images/hmc-extension-images-<version>.tgz` - The image bundle tarball for
+    - `images/kcm-extension-images-<version>.tgz` - The image bundle tarball for
       the managed clusters, this bundle will be pushed to a registry where the
       images can be accessed by the managed clusters.
-    - `charts` - Contains the HMC Helm chart, dependency charts and k0s
+    - `charts` - Contains the kcm Helm chart, dependency charts and k0s
       extensions charts within the `extensions` directory.  All of these charts
       will be pushed to a chart repository within a registry.
     - `scripts/airgap-push.sh` - A script that will aid in re-tagging and
@@ -63,8 +63,8 @@ following:
    the script.
 
      ```bash
-     tar xvf hmc-airgap-<version>.tgz scripts/airgap-push.sh
-     ./scripts/airgap-push.sh -r <registry> -c <chart-repo> -a hmc-airgap-<version>.tgz
+     tar xvf kcm-airgap-<version>.tgz scripts/airgap-push.sh
+     ./scripts/airgap-push.sh -r <registry> -c <chart-repo> -a kcm-airgap-<version>.tgz
      ```
 
 3. Next, extract the `management` bundle tarball and sync the images to the
@@ -74,23 +74,23 @@ following:
      > NOTE:
      > Multiple image bundles can be placed in the `/var/lib/k0s/images`
      > directory for k0s to use and the existing `k0s` airgap bundle does not
-     > need to be merged into the `hmc-images-<version>.tgz` bundle.
+     > need to be merged into the `kcm-images-<version>.tgz` bundle.
 
      ```bash
-     tar -C /var/lib/k0s -xvf hmc-airgap-<version>.tgz "images/hmc-images-<version>.tgz"
+     tar -C /var/lib/k0s -xvf kcm-airgap-<version>.tgz "images/kcm-images-<version>.tgz"
      ```
 
-4. Install the HMC Helm chart on the management cluster from the registry where
-   the HMC charts were pushed.  The HMC controller image is loaded as part of
+4. Install the kcm Helm chart on the management cluster from the registry where
+   the kcm charts were pushed.  The kcm controller image is loaded as part of
    the airgap `management` bundle and does not need to be customized within the
    Helm chart, but the default chart repository configured via
    `controller.defaultRegistryURL` should be set to reference the repository
    where charts have been pushed.
 
       ```bash
-      helm install hmc oci://<chart-repository>/hmc \
+      helm install kcm oci://<chart-repository>/kcm \
         --version <version> \
-        -n hmc-system \
+        -n kcm-system \
         --create-namespace \
         --set controller.defaultRegistryURL=oci://<chart-repository>
       ```
@@ -107,13 +107,13 @@ following:
       apiVersion: k0rdent.mirantis.com/v1alpha1
       kind: Management
       metadata:
-        name: hmc
+        name: kcm
       spec:
         core:
           capi:
             config:
               airgap: true
-          hmc:
+          kcm:
             config:
               controller:
                 defaultRegistryURL: oci://<registry-url>

--- a/docs/usage/cluster-update.md
+++ b/docs/usage/cluster-update.md
@@ -6,13 +6,13 @@ object to the new `ClusterTemplate` name:
 Run:
 
 ```shell
-kubectl patch clusterdeployment.hmc <cluster-name> -n <namespace> --patch '{"spec":{"template":"<new-template-name>"}}' --type=merge
+kubectl patch clusterdeployment.kcm <cluster-name> -n <namespace> --patch '{"spec":{"template":"<new-template-name>"}}' --type=merge
 ```
 
 Then, check the status of the `ClusterDeployment` object:
 
 ```shell
-kubectl get clusterdeployment.hmc <cluster-name> -n <namespace>
+kubectl get clusterdeployment.kcm <cluster-name> -n <namespace>
 ```
 
 In the commands above, replace the parameters enclosed in angle brackets with

--- a/docs/usage/create-cluster-deployment.md
+++ b/docs/usage/create-cluster-deployment.md
@@ -9,14 +9,14 @@
 
 ### Step 2: Select the Template
 
-For details about the templates in Project 2A, see the [Templates system](../template/main.md).
+For details about the templates in k0rdent, see the [Templates system](../template/main.md).
 
 - Set the `KUBECONFIG` environment variable to the path to the management
   cluster kubeconfig file. Then select the `Template` you want to use for the
   deployment. To list all available templates, run:
 
   ```shell
-  kubectl get clustertemplate -n hmc-system
+  kubectl get clustertemplate -n kcm-system
   ```
 
 > NOTE:
@@ -36,7 +36,7 @@ For details about the templates in Project 2A, see the [Templates system](../tem
     kind: ClusterDeployment
     metadata:
       name: <cluster-name>
-      namespace: <hmc-system-namespace>
+      namespace: <kcm-system-namespace>
     spec:
       template: <template-name>
       credential: <infrastructure-provider-credential-name>
@@ -60,7 +60,7 @@ Following is an interpolated example.
 > kind: ClusterDeployment
 > metadata:
 >   name: my-managed-cluster
->   namespace: hmc-system
+>   namespace: kcm-system
 > spec:
 >   template: aws-standalone-cp-0-0-3
 >   credential: aws-credential
@@ -75,7 +75,7 @@ Following is an interpolated example.
 
 ### Step 4: Apply the `ClusterDeployment` Configuration to Create it
 
-- Apply the `ClusterDeployment` object to your Project 2A deployment:
+- Apply the `ClusterDeployment` object to your k0rdent deployment:
 
 	```shell
 	kubectl apply -f clusterdeployment.yaml
@@ -86,7 +86,7 @@ Following is an interpolated example.
 - Check the status of the newly created `ClusterDeployment`:
 
 	```shell
-	kubectl -n <namespace> get clusterdeployment.hmc <cluster-name> -o=yaml
+	kubectl -n <namespace> get clusterdeployment.kcm <cluster-name> -o=yaml
 	```
 
 > INFO:
@@ -122,7 +122,7 @@ Following is an interpolated example.
 
 ## Dry Run
 
-Project 2A `ClusterDeployment` supports two modes: with and without `.spec.dryRun`
+k0rdent `ClusterDeployment` supports two modes: with and without `.spec.dryRun`
 (defaults to `false`).
 
 If no configuration (`.spec.config`) is specified, the `ClusterDeployment` object
@@ -137,7 +137,7 @@ corresponding `Template` status) and automatically have `.spec.dryRun` set to
 > kind: ClusterDeployment
 > metadata:
 >   name: my-managed-cluster
->   namespace: hmc-system
+>   namespace: kcm-system
 > spec:
 >   config:
 >     clusterNetwork:
@@ -179,7 +179,7 @@ Here is an example of a `ClusterDeployment` object that passed the validation:
 > kind: ClusterDeployment
 > metadata:
 >   name: my-managed-cluster
->   namespace: hmc-system
+>   namespace: kcm-system
 > spec:
 >   template: aws-standalone-cp-0-0-3
 >   credential: aws-credential
@@ -212,29 +212,29 @@ Here is an example of a `ClusterDeployment` object that passed the validation:
 >     observedGeneration: 1
 > ```
 
-<!-- This Cleanup section describes uninstalling project 2A from the super cluster and hence should be in its own file. -->
+<!-- This Cleanup section describes uninstalling k0rdent from the super cluster and hence should be in its own file. -->
 
 ## Cleanup
 
 1. Remove the Management object:
 
 	```shell
-	kubectl delete management.hmc hmc
+	kubectl delete management.kcm kcm
 	```
 
 > NOTE:
 >
-> Ensure you have no Project 2A `ClusterDeployment` objects left in the cluster
+> Ensure you have no k0rdent `ClusterDeployment` objects left in the cluster
 > prior to Management deletion.
 
-2. Remove the `hmc` Helm release:
+2. Remove the `kcm` Helm release:
 
 	```shell
-	helm uninstall hmc -n hmc-system
+	helm uninstall kcm -n kcm-system
 	```
 
-3. Remove the `hmc-system` namespace:
+3. Remove the `kcm-system` namespace:
 
 	```shell
-	kubectl delete ns hmc-system
+	kubectl delete ns kcm-system
 	```

--- a/docs/usage/create-multiclusterservice.md
+++ b/docs/usage/create-multiclusterservice.md
@@ -29,16 +29,16 @@ spec:
 
 Consider the following example where 2 clusters have been deployed using ClusterDeployment objects:
 ```sh
-➜  ~ kubectl get clusterdeployments.k0rdent.mirantis.com -n hmc-system
+➜  ~ kubectl get clusterdeployments.k0rdent.mirantis.com -n kcm-system
 NAME             READY   STATUS
 dev-cluster-1   True    ClusterDeployment is ready
 dev-cluster-2   True    ClusterDeployment is ready
 ➜  ~ 
 ➜  ~ 
-➜  ~  kubectl get cluster -n hmc-system --show-labels
+➜  ~  kubectl get cluster -n kcm-system --show-labels
 NAME           CLUSTERCLASS     PHASE         AGE     VERSION   LABELS
-dev-cluster-1                  Provisioned   2h41m             app.kubernetes.io/managed-by=Helm,helm.toolkit.fluxcd.io/name=dev-cluster-1,helm.toolkit.fluxcd.io/namespace=hmc-system,sveltos-agent=present
-dev-cluster-2                  Provisioned   3h10m             app.kubernetes.io/managed-by=Helm,helm.toolkit.fluxcd.io/name=dev-cluster-2,helm.toolkit.fluxcd.io/namespace=hmc-system,sveltos-agent=present
+dev-cluster-1                  Provisioned   2h41m             app.kubernetes.io/managed-by=Helm,helm.toolkit.fluxcd.io/name=dev-cluster-1,helm.toolkit.fluxcd.io/namespace=kcm-system,sveltos-agent=present
+dev-cluster-2                  Provisioned   3h10m             app.kubernetes.io/managed-by=Helm,helm.toolkit.fluxcd.io/name=dev-cluster-2,helm.toolkit.fluxcd.io/namespace=kcm-system,sveltos-agent=present
 ```
 
 > EXAMPLE: 
@@ -49,7 +49,7 @@ dev-cluster-2                  Provisioned   3h10m             app.kubernetes.io
 > metadata:
 >   . . . 
 >   name: dev-cluster-1
->   namespace: hmc-system
+>   namespace: kcm-system
 > spec:
 >   . . .
 >   services:
@@ -71,7 +71,7 @@ dev-cluster-2                  Provisioned   3h10m             app.kubernetes.io
 > metadata:
 >   . . .
 >   name: dev-cluster-2
->   namespace: hmc-system
+>   namespace: kcm-system
 > spec:
 >   . . .
 >   services:
@@ -174,7 +174,7 @@ and 1 MultiClusterService is deployed.
 >   observedGeneration: 1
 >   services:
 >   - clusterName: dev-cluster-2
->     clusterNamespace: hmc-system
+>     clusterNamespace: kcm-system
 >     conditions:
 >     - lastTransitionTime: "2024-10-25T08:36:35Z"
 >       message: |
@@ -189,7 +189,7 @@ and 1 MultiClusterService is deployed.
 >       status: "False"
 >       type: ingress-nginx.ingress-nginx/SveltosHelmReleaseReady
 >   - clusterName: dev-cluster-1
->     clusterNamespace: hmc-system
+>     clusterNamespace: kcm-system
 >     conditions:
 >     - lastTransitionTime: "2024-10-25T08:36:24Z"
 >       message: ""
@@ -213,7 +213,7 @@ Whereas, it shows provisioned for `dev-cluster-1` because the MultiClusterServic
 > metadata:
 >   . . . 
 >   name: dev-cluster-1
->   namespace: hmc-system
+>   namespace: kcm-system
 >   . . .
 > spec:
 >   . . .
@@ -231,7 +231,7 @@ Whereas, it shows provisioned for `dev-cluster-1` because the MultiClusterServic
 >   . . .
 >   services:
 >   - clusterName: dev-cluster-1
->     clusterNamespace: hmc-system
+>     clusterNamespace: kcm-system
 >     conditions:
 >     - lastTransitionTime: "2024-10-25T08:36:35Z"
 >       message: |
@@ -262,7 +262,7 @@ another object with higher priority is managing it, so it shows a conflict inste
 > metadata:
 >   . . .
 >   name: dev-cluster-2
->   namespace: hmc-system
+>   namespace: kcm-system
 >   resourceVersion: "30889"
 >   . . .
 > spec:
@@ -278,7 +278,7 @@ another object with higher priority is managing it, so it shows a conflict inste
 >   . . .
 >   services:
 >   - clusterName: dev-cluster-2
->     clusterNamespace: hmc-system
+>     clusterNamespace: kcm-system
 >     conditions:
 >     - lastTransitionTime: "2024-10-25T08:18:22Z"
 >       message: ""

--- a/docs/usage/deploy-services-clusterdeployment.md
+++ b/docs/usage/deploy-services-clusterdeployment.md
@@ -12,7 +12,7 @@ Consider the following example:
 > kind: ClusterDeployment
 > metadata:
 >   name: my-managed-cluster
->   namespace: hmc-system
+>   namespace: kcm-system
 > spec:
 >   config:
 >     clusterNetwork:
@@ -79,7 +79,7 @@ the service template for kyverno.
 > kind: ServiceTemplate
 > metadata:
 >   name: kyverno-3-2-6
->   namespace: hmc-system
+>   namespace: kcm-system
 > spec:
 >   helm:
 >     chartSpec:
@@ -88,11 +88,11 @@ the service template for kyverno.
 >       reconcileStrategy: ChartVersion
 >       sourceRef:
 >         kind: HelmRepository
->         name: hmc-templates
+>         name: kcm-templates
 >       version: 3.2.6
 > ```
 
-The `hmc-templates` helm repository hosts the actual chart for kyverno version 3.2.6.
+The `kcm-templates` helm repository hosts the actual chart for kyverno version 3.2.6.
 For more details see the [Bring your own Templates](../template/byo-templates.md) guide.
 
 ### Configuring Custom Values
@@ -106,7 +106,7 @@ kind: ClusterDeployment
 metadata:
   . . .
   name: my-clusterdeployment
-  namespace: hmc-system
+  namespace: kcm-system
   . . .
 spec:
   . . .
@@ -125,13 +125,13 @@ spec:
         victoriametrics:
           vmauth:
             ingress:
-              host: vmauth.hmc0.example.net
+              host: vmauth.kcm0.example.net
             credentials:
               username: motel
               password: motel
         grafana:
           ingress:
-            host: grafana.hmc0.example.net
+            host: grafana.kcm0.example.net
         cert-manager:
           email: mail@example.net
     - template: ingress-nginx-4-11-3
@@ -152,7 +152,7 @@ apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ClusterDeployment
 metadata:
   name: my-clusterdeployment
-  namespace: hmc-system
+  namespace: kcm-system
 spec:
   . . .
   servicesPriority: 100
@@ -182,7 +182,7 @@ The `.status.services` field of the `ClusterDeployment` object shows the status 
 >   . . .
 >   generation: 1
 >   name: wali-aws-dev
->   namespace: hmc-system
+>   namespace: kcm-system
 >   . . .
 > spec:
 >   . . .
@@ -197,7 +197,7 @@ The `.status.services` field of the `ClusterDeployment` object shows the status 
 >   observedGeneration: 1
 >   services:
 >   - clusterName: my-managed-cluster
->     clusterNamespace: hmc-system
+>     clusterNamespace: kcm-system
 >     conditions:
 >     - lastTransitionTime: "2024-12-11T23:03:05Z"
 >       message: ""
@@ -249,7 +249,7 @@ The example below removes `kyverno-3-2-6` so its status also removed from `.stat
 >   . . .
 >   generation: 2
 >   name: wali-aws-dev
->   namespace: hmc-system
+>   namespace: kcm-system
 >   . . .
 > spec:
 >   . . .
@@ -264,7 +264,7 @@ The example below removes `kyverno-3-2-6` so its status also removed from `.stat
 >   observedGeneration: 2
 >   services:
 >   - clusterName: wali-aws-dev
->     clusterNamespace: hmc-system
+>     clusterNamespace: kcm-system
 >     conditions:
 >     - lastTransitionTime: "2024-12-11T23:15:45Z"
 >       message: ""

--- a/docs/usage/installation.md
+++ b/docs/usage/installation.md
@@ -1,6 +1,6 @@
 # Installation Guide
 
-This section describes how to install Project 2A.
+This section describes how to install k0rdent.
 
 ## TL;DR
 
@@ -9,7 +9,7 @@ export KUBECONFIG=<path-to-management-kubeconfig>
 ```
 
 ```bash
-helm install hmc oci://ghcr.io/k0rdent/kcm/charts/hmc --version <hmc-version> -n hmc-system --create-namespace
+helm install kcm oci://ghcr.io/k0rdent/kcm/charts/kcm --version <kcm-version> -n kcm-system --create-namespace
 ```
 
 This will use the defaults as seen in Extended Management Configuration section below.
@@ -20,14 +20,14 @@ Releases are tagged in the GitHub repository and can be found [here](https://git
 
 ## Extended Management Configuration
 
-Project 2A is deployed with the following default configuration, which may vary
+k0rdent is deployed with the following default configuration, which may vary
 depending on the release version:
 
 ```yaml
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: Management
 metadata:
-  name: hmc
+  name: kcm
 spec:
   providers:
   - name: k0smotron
@@ -35,28 +35,28 @@ spec:
   - name: cluster-api-provider-azure
   - name: cluster-api-provider-vsphere
   - name: projectsveltos
-  release: hmc-0-0-6
+release: kcm-0-0-7
 ```
 To see what is included in a specific release, look at the `release.yaml` file in the tagged release.
-For example, here is the [v0.0.6 release.yaml](https://github.com/k0rdent/kcm/releases/download/v0.0.6/release.yaml).
+For example, here is the [v0.0.7 release.yaml](https://github.com/k0rdent/kcm/releases/download/v0.0.7/release.yaml).
 
-There are two options to override the default management configuration of Project 2A:
+There are two options to override the default management configuration of k0rdent:
 
-1. Update the `Management` object after the Project 2A installation using `kubectl`:
+1. Update the `Management` object after the k0rdent installation using `kubectl`:
 
     `kubectl --kubeconfig <path-to-management-kubeconfig> edit management`
 
-2. Deploy 2A skipping the default `Management` object creation and provide your
+2. Deploy k0rdent skipping the default `Management` object creation and provide your
    own `Management` configuration:
 
 	- Create `management.yaml` file and configure core components and providers.
-	- Specify `--create-management=false` controller argument and install Project 2A:
+	- Specify `--create-management=false` controller argument and install k0rdent:
 	  If installing using `helm` add the following parameter to the `helm
 	  install` command:
 
 		  `--set="controller.createManagement=false"`
 
-	- Create `hmc` `Management` object after Project 2A installation:
+	- Create `kcm` `Management` object after k0rdent installation:
 
            ```bash
            kubectl --kubeconfig <path-to-management-kubeconfig> create -f management.yaml
@@ -65,28 +65,28 @@ There are two options to override the default management configuration of Projec
 ## Air-gapped installation
 
 Follow the [Air-gapped Installation Guide](airgap.md) to get the instructions on
-how to perform 2A installation in the air-gapped environment.
+how to perform k0rdent installation in the air-gapped environment.
 
 ## Cleanup
 
 1. Remove the Management object:
 
   ```bash
-	kubectl delete management.hmc hmc
+	kubectl delete management.kcm kcm
   ```
 
 > WARNING: 
 > 
-> Make sure you have no Project 2A `ClusterDeployment` objects left in the cluster prior to deletion.
+> Make sure you have no k0rdent `ClusterDeployment` objects left in the cluster prior to deletion.
 
-2. Remove the `hmc` Helm release:
+2. Remove the `kcm` Helm release:
 
   ```bash
-	helm uninstall hmc -n hmc-system
+	helm uninstall kcm -n kcm-system
   ```
 
-3. Remove the `hmc-system` namespace:
+3. Remove the `kcm-system` namespace:
 
   ```bash
-	kubectl delete ns hmc-system
+	kubectl delete ns kcm-system
   ```

--- a/docs/usage/upgrade.md
+++ b/docs/usage/upgrade.md
@@ -1,17 +1,17 @@
-# Upgrading 2A to the newer version
+# Upgrading k0rdent to the newer version
 
-> NOTE: To upgrade 2A the user must have `Global Admin` role.
-> For the detailed information about 2A RBAC, refer to the [RBAC documentation](../rbac/roles.md).
+> NOTE: To upgrade k0rdent the user must have `Global Admin` role.
+> For the detailed information about k0rdent RBAC, refer to the [RBAC documentation](../rbac/roles.md).
 
-Follow the steps below to update 2A to a newer version:
+Follow the steps below to update k0rdent to a newer version:
 
 **Step 1. Create a New `Release` Object**
 
 Create a `Release` object in the management cluster for the desired version. For example, to create
-a `Release` for version `v0.0.6`, run the following command:
+a `Release` for version `v0.0.7`, run the following command:
 
 ```shell
-VERSION=v0.0.6
+VERSION=v0.0.7
 kubectl create -f https://github.com/k0rdent/kcm/releases/download/${VERSION}/release.yaml
 ```
 
@@ -29,18 +29,18 @@ Example output:
 
 ```shell
 NAME        AGE
-hmc-0-0-5   71m
-hmc-0-0-6   65m
+kcm-0-0-5   71m
+kcm-0-0-7   65m
 ```
 
 - Patch the `Management` Object with the New `Release` Name:
 
-Update the `spec.release` field in the `Management` object to point to the new release. Replace `hmc-0-0-4` with
+Update the `spec.release` field in the `Management` object to point to the new release. Replace `kcm-0-0-4` with
 the name of your new release:
 
 ```shell
-RELEASE_NAME=hmc-0-0-6
-kubectl patch management.hmc hmc --patch "{\"spec\":{\"release\":\"${RELEASE_NAME}\"}}" --type=merge
+RELEASE_NAME=kcm-0-0-7
+kubectl patch management.kcm kcm --patch "{\"spec\":{\"release\":\"${RELEASE_NAME}\"}}" --type=merge
 ```
 
 **Step 3. Verify the Upgrade**
@@ -48,5 +48,5 @@ kubectl patch management.hmc hmc --patch "{\"spec\":{\"release\":\"${RELEASE_NAM
 Check the status of the `Management` object to monitor the readiness of the components:
 
 ```shell
-kubectl get management.hmc hmc -o=jsonpath={.status} | jq
+kubectl get management.kcm kcm -o=jsonpath={.status} | jq
 ```

--- a/docs/usage/upgrade.md
+++ b/docs/usage/upgrade.md
@@ -29,7 +29,7 @@ Example output:
 
 ```shell
 NAME        AGE
-kcm-0-0-5   71m
+kcm-0-0-6   71m
 kcm-0-0-7   65m
 ```
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -78,7 +78,7 @@ nav:
   - Usage:
       - Installation Guide: usage/installation.md
       - Adopting Existing Clusters Guide: usage/adopt-existing-cluster.md
-      - Air-gapped Installation Guide: usage/airgap.md
+#     - Air-gapped Installation Guide: usage/airgap.md
       - Create Cluster Deployment: usage/create-cluster-deployment.md
       - Cluster Updates: usage/cluster-update.md
       - k0rdent Upgrade: usage/upgrade.md


### PR DESCRIPTION
Major changes to change all instances of HMC/hmc to kcm, fix all instances of Project 2A or 2A to k0rdent, a couple of small similar tweaks.  Change version examples to 0.0.7 from 0.0.6.