### PR TITLE
Backup documentation amends

### DIFF
--- a/docs/disaster-recovery/customization.md
+++ b/docs/disaster-recovery/customization.md
@@ -11,41 +11,63 @@ and is enabled by default.
 There are 2 ways of customizing the chart values similar to
 the [installation guide](../usage/installation.md#extended-management-configuration):
 
-1. If installing using `helm` add corresponding parameters to the `helm install` command,
-   for example:
+1. Install using `helm` and add corresponding parameters to the `helm install` command.
 
-    ```bash
-    helm install kcm oci://ghcr.io/k0rdent/kcm/charts/kcm \
-     --version <version> \
-     --create-namespace \
-     --namespace kcm-system \
-     --set velero.initContainers[0].name=velero-plugin-for-<PROVIDER NAME> \
-     --set velero.initContainers[0].image=velero/velero-plugin-for-<PROVIDER NAME>:<PROVIDER PLUGIN TAG> \
-     --set velero.initContainers[0].volumeMounts[0].mountPath=/target \
-     --set velero.initContainers[0].volumeMounts[0].name=plugins
-    ```
+    > NOTE:
+    > Only a plugin is required during the restoration, the other parameters
+    > are optional to be set.
 
-2. Create or modify the existing `Management` object in the `.spec.config.kcm`, for example:
+    > EXAMPLE: An example of `helm install` with a configured plugin, `BackupStorageLocation`
+    > and propagated credentials:
+    >
+    > ```bash
+    > helm install kcm oci://ghcr.io/k0rdent/kcm/charts/kcm \
+    >  --version <version> \
+    >  --create-namespace \
+    >  --namespace kcm-system \
+    >  --set-file velero.credentials.secretContents.cloud=<FULL PATH TO FILE> \
+    >  --set velero.credentials.useSecret=true \
+    >  --set velero.backupsEnabled=true \
+    >  --set velero.configuration.backupStorageLocation[0].name=<backup-storage-location-name> \
+    >  --set velero.configuration.backupStorageLocation[0].provider=<provider-name> \
+    >  --set velero.configuration.backupStorageLocation[0].bucket=<bucket-name> \
+    >  --set velero.configuration.backupStorageLocation[0].config.region=<region> \
+    >  --set velero.initContainers[0].name=velero-plugin-for-<provider-name> \
+    >  --set velero.initContainers[0].image=velero/velero-plugin-for-<provider-name>:<provider-plugin-tag> \
+    >  --set velero.initContainers[0].volumeMounts[0].mountPath=/target \
+    >  --set velero.initContainers[0].volumeMounts[0].name=plugins
+    > ```
 
-    ```yaml
-    apiVersion: k0rdent.mirantis.com/v1alpha1
-    kind: Management
-    metadata:
-      name: kcm
-    spec:
-      core:
-        kcm:
-          config:
-            velero:
-             initContainers:
-               - name: velero-plugin-for-<PROVIDER NAME>
-                 image: velero/velero-plugin-for-<PROVIDER NAME>:<PROVIDER PLUGIN TAG>
-                 imagePullPolicy: IfNotPresent
-                 volumeMounts:
-                   - mountPath: /target
-                     name: plugins
-          # ...
-    ```
+2. Create or modify the existing `Management` object in the `.spec.config.kcm`.
+
+    > NOTE:
+    > Only a plugin is required during the restoration, the other parameters
+    > are optional to be set.
+
+    > EXAMPLE: An example of `Management` object with a configured plugin and enabled metrics:
+    >
+    > ```yaml
+    > apiVersion: k0rdent.mirantis.com/v1alpha1
+    > kind: Management
+    > metadata:
+    >   name: kcm
+    > spec:
+    >   # ...
+    >   core:
+    >     kcm:
+    >       config:
+    >         velero:
+    >           initContainers:
+    >           - name: velero-plugin-for-<provider-name>
+    >             image: velero/velero-plugin-for-<provider-name>:<provider-plugin-tag>
+    >             imagePullPolicy: IfNotPresent
+    >             volumeMounts:
+    >             - mountPath: /target
+    >               name: plugins
+    >           metrics:
+    >             enabled: true
+    >   # ...
+    > ```
 
 To fully disable `velero`, set the `velero.enabled` parameter to `false`.
 
@@ -64,10 +86,10 @@ The following list contains `.spec.schedule` acceptable example values:
 - `@hourly` (nonstandard predefined definition)
 - `@every 1h` (extra definition)
 
-## Putting extra objects in a Backup
+## Putting extra objects in a Management Backup
 
 If a situation arises in which it is necessary to back up some
-additional objects in addition to those [backed up by default](overview.md#whats-included-in-the-backup),
+additional objects in addition to those [backed up by default](overview.md#whats-included-in-the-management-backup),
 it is enough to add the following label `k0rdent.mirantis.com/component="kcm"` to these objects.
 
-All objects containing the label will be automatically added to the backup.
+All objects containing the label will be automatically added to the management backup.

--- a/docs/disaster-recovery/overview.md
+++ b/docs/disaster-recovery/overview.md
@@ -1,7 +1,7 @@
 # Disaster Recovery Feature Overview
 
 This document provides an overview of the disaster recovery feature used to back up and restore
-a `kcm` management cluster.
+the **`kcm` management cluster**.
 
 The feature leverages [`velero`](https://velero.io/) for backup management
 on the backend and integrates with the `kcm` to ensure data persistence and recovery.
@@ -15,15 +15,16 @@ different cloud storage while maintaining the integrity of critical resources.
 
 The main goal of the feature is to provide:
 
-- Backup: the ability to backup all configuration objects **created and managed by the `kcm`**
+- Management Backup: the ability to backup all configuration objects **created and managed by the `kcm`**
   into an offsite location.
-- Restore: the ability to create configuration objects from a specific Backup.
+- Restore: the ability to create configuration objects from a specific Management Backup
+  **without (re)provisioning of cloud resources**.
 - Disaster Recovery: the ability to restore the `kcm` system on another management cluster
   using restore capability, plus ensuring that clusters are not recreated or lost.
 - Rollback: the possibility to manually restore after a specific event, e.g. a failed upgrade
   of the `kcm`.
 
-## Velero as Provider for Backups
+## Velero as Provider for Management Backups
 
 [`Velero`](https://velero.io/) is an open-source tool that simplifies backing up and restoring clusters as well as individual resources. It seamlessly integrates into the `kcm` management environment to provide robust disaster recovery capabilities.
 
@@ -35,14 +36,39 @@ data to be included in a backup.
 
 Customization options for the installation and backups are covered by [the according section](customization.md).
 
-## Scheduled Backups
+## Scheduled Management Backups
 
 ### Preparation
 
 Before the creation of scheduled backups, several actions should be performed beforehand:
 
+1. If no `velero` pluguns have not been yet installed as suggested
+   in the [corresponding section](customization.md#velero-installation),
+   install it modifying the `Management` object:
+
+    ```yaml
+    apiVersion: k0rdent.mirantis.com/v1alpha1
+    kind: Management
+    metadata:
+      name: kcm
+    spec:
+      # ... 
+      core:
+        kcm:
+          config:
+            velero:
+              initContainers:
+              - name: velero-plugin-for-<provider-name>
+                image: velero/velero-plugin-for-<provider-name>:<provider-plugin-tag>
+                imagePullPolicy: IfNotPresent
+                volumeMounts:
+                - mountPath: /target
+                  name: plugins
+      # ...
+    ```
+
 1. Prepare a cloud storage to save backups to (e.g. `Amazon S3`).
-2. Create a [`BackupStorageLocation`](https://velero.io/docs/v1.15/api-types/backupstoragelocation/)
+1. Create a [`BackupStorageLocation`](https://velero.io/docs/v1.15/api-types/backupstoragelocation/)
    object referencing a `Secret` with credentials to access the cloud storage
    (if the multiple credentials feature is supported by the plugin).
 
@@ -88,11 +114,11 @@ Before the creation of scheduled backups, several actions should be performed be
 > For more comprehensive examples and to familiarize yourself with limitations and caveats
 > please follow the link to the [official location documentation](https://velero.io/docs/v1.15/locations).
 
-### Create Backup
+### Create Management Backup
 
 To set a `ManagementBackup` object to create periodic backups,
 set the `.spec.schedule` field with a [Cron](https://en.wikipedia.org/wiki/Cron) expression.
-If the `.spec.schedule` is not set, the [backup on demand](#backup-on-demand) will be created instead.
+If the `.spec.schedule` is not set, the [backup on demand](#management-backup-on-demand) will be created instead.
 
 Optionally, set the name of the `BackupStorageLocation` `.spec.backup.storageLocation`.
 The default location is the `BackupStorageLocation` object with `.spec.default` set to `true`.
@@ -110,7 +136,7 @@ The default location is the `BackupStorageLocation` object with `.spec.default` 
 >   storageLocation: aws-s3
 >```
 
-## Backup on Demand
+## Management Backup on Demand
 
 To create a single backup of the `kcm`, a `ManagementBackup` object can be created
 manually, e.g. via the `kubectl` CLI. The object then creates only one instance of backup.
@@ -126,7 +152,7 @@ manually, e.g. via the `kubectl` CLI. The object then creates only one instance 
 >   storageLocation: my-location
 >```
 
-## What's Included in the Backup
+## What's Included in the Management Backup
 
 The backup includes all of the `kcm` component resources, parts of the `cert-manager`
 components required for other components creation, and all the required resources
@@ -148,19 +174,18 @@ of `CAPI` and `ClusterDeployment`s currently in use in the management cluster.
 
 ## Restoration
 
-> NOTE: Caveats and limitations
+> NOTE:
 >
 > Please refer to the
 > [official migration documentation](https://velero.io/docs/v1.15/migration-case/#before-migrating-your-cluster)
-> to be familiarized with potential limitations.
+> to be familiarized with potential Velero limitations.
+
+### General case
 
 To restore from a backup in the event of a disaster, the following actions should be
 performed:
 
-1. Ensure a сlean `kcm` installation. For more information, please refer
-   to the [installation guide](../usage/installation.md#extended-management-configuration).
-
-    For example:
+1. Ensure a сlean `kcm` installation including `velero` and [its plugins](customization.md#velero-installation):
 
     ```bash
     helm install kcm oci://ghcr.io/k0rdent/kcm/charts/kcm \
@@ -171,63 +196,271 @@ performed:
      --set controller.createAccessManagement=false \
      --set controller.createRelease=false \
      --set controller.createTemplates=false
+     --set velero.initContainers[0].name=velero-plugin-for-<provider-name> \
+     --set velero.initContainers[0].image=velero/velero-plugin-for-<provider-name>:<provider-plugin-tag> \
+     --set velero.initContainers[0].volumeMounts[0].mountPath=/target \
+     --set velero.initContainers[0].volumeMounts[0].name=plugins
     ```
 
-2. Create the `BackupStorageLocation`/`Secret` objects that had been
+    For more information, please refer
+    to the [installation guide](../usage/installation.md#extended-management-configuration).
+
+1. Create the `BackupStorageLocation`/`Secret` objects that had been
    created during the [preparation stage](#preparation) (preferably the same depending on a plugin).
-3. Restore the `kcm` system: either use the [velero CLI](https://velero.io/docs/v1.15/basic-install/#install-the-cli)
-   or directly create [`Restore`](https://velero.io/docs/v1.15/api-types/restore/) object.
+1. Restore the `kcm` system creating the [`Restore`](https://velero.io/docs/v1.15/api-types/restore/) object,
+   it is important to set the `.spec.existingResourcePolicy` field value to `update`:
 
-    > EXAMPLE: A `Restore` object:
-    >
-    >```yaml
-    > apiVersion: velero.io/v1
-    > kind: Restore
-    > metadata:
-    >   name: <restore-name>
-    >   namespace: kcm-system
-    > spec:
-    >   backupName: <backup-name>
-    >   excludedResources:
-    >   # the following are velero defaults, so it is recommended to keep them
-    >   - nodes
-    >   - events
-    >   - events.events.k8s.io
-    >   - backups.velero.io
-    >   - restores.velero.io
-    >   - resticrepositories.velero.io
-    >   - csinodes.storage.k8s.io
-    >   - volumeattachments.storage.k8s.io
-    >   - backuprepositories.velero.io
-    >   existingResourcePolicy: update
-    >   includedNamespaces:
-    >   - '*'
-    >```
+    ```yaml
+     apiVersion: velero.io/v1
+     kind: Restore
+     metadata:
+       name: <restore-name>
+       namespace: kcm-system
+     spec:
+       backupName: <backup-name>
+       existingResourcePolicy: update
+       includedNamespaces:
+       - '*'
+    ```
 
-    > EXAMPLE: A `velero` CLI command:
-    >
-    >```bash
-    > velero --namespace kcm-system restore create <restore-name> --existing-resource-policy update --from-backup <backup-name>
-    >```
+1. Wait until the `Restore` status is `Completed` and all `kcm` components are up and running.
 
-4. Wait until the `Restore` status is `Completed` and all `kcm` components are up and running.
+### Caveats
 
-<!-- ## Upgrades and rollback
+For some `CAPI` providers it is necessary to make changes to the `Restore`
+object due to the large number of different resources and logic in each provider.
+The resources described below are not excluded from a `ManagementBackup` by
+default to avoid logical dependencies on one or another provider
+and continue to be provider-agnostic.
 
-TODO: fill out this section when the upgrade backup is implemented
+> NOTE:
+> The described caveats apply only to the step with the `Restore`
+> object creation and do not affect the other steps.
 
-Describe that the backup is created each time before the `kcm` upgrade.
+#### Azure (CAPZ)
 
-Refer to how to rollback properly (probably just follow the restoration part)
+The following resources should be excluded from the `Restore` object:
 
-TBD, no implementation exists yet -->
+- `natgateways.network.azure.com`
+- `resourcegroups.resources.azure.com`
+- `virtualnetworks.network.azure.com`
+- `virtualnetworkssubnets.network.azure.com`
+
+Due to the [webhook conversion](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definition-versioning/#webhook-conversion),
+objects of these resources cannot be restored, and they will
+be created in the management cluster by the `CAPZ` provider
+automatically with the same `spec` as in the backup.
+
+The resulting `Restore` object:
+
+```yaml
+ apiVersion: velero.io/v1
+ kind: Restore
+ metadata:
+   name: <restore-name>
+   namespace: kcm-system
+ spec:
+   backupName: <backup-name>
+   existingResourcePolicy: update
+   excludedResources:
+   - natgateways.network.azure.com
+   - resourcegroups.resources.azure.com
+   - virtualnetworks.network.azure.com
+   - virtualnetworkssubnets.network.azure.com
+   includedNamespaces:
+   - '*'
+```
+
+#### vSphere (CAPV)
+
+The following resources should be excluded from the `Restore` object:
+
+- `mutatingwebhookconfiguration.admissionregistration.k8s.io`
+- `validatingwebhookconfiguration.admissionregistration.k8s.io`
+
+Due to the [Velero Restoration Order](https://velero.io/docs/v1.15/restore-reference/#restore-order),
+some of the `CAPV` core objects cannot be restored,
+and they will not be restored automatically.
+Since all of the objects have already passed both mutations
+and validations, there is not much sense in validating them again.
+The webhook configurations will be restored during installation
+of the `CAPV` provider.
+
+The resulting `Restore` object:
+
+```yaml
+ apiVersion: velero.io/v1
+ kind: Restore
+ metadata:
+   name: <restore-name>
+   namespace: kcm-system
+ spec:
+   backupName: <backup-name>
+   existingResourcePolicy: update
+   excludedResources:
+   - mutatingwebhookconfiguration.admissionregistration.k8s.io
+   - validatingwebhookconfiguration.admissionregistration.k8s.io
+   includedNamespaces:
+   - '*'
+```
+
+## Upgrades and rollback
+
+The Disaster Recovery Feature provides a way to create backups
+on each `kcm` upgrade automatically.
+
+### Automatic Management Backups
+
+Each `ManagementBackup` with *non-empty* `.spec.schedule` field
+can enable the automatic creation of backups before
+[upgrading](../usage/upgrade.md) to a new version.
+
+To enable, set the `.spec.performOnManagementUpgrade` to `true`.
+
+> EXAMPLE: An example of a `ManagementBackup` object with enabled auto-backup before the `kcm` version upgrade:
+>
+>```yaml
+> apiVersion: k0rdent.mirantis.com/v1alpha1
+> kind: ManagementBackup
+> metadata:
+>   name: example-backup
+> spec:
+>   schedule: "0 */6 * * *"
+>   performOnManagementUpgrade: true
+>```
+
+After the enablement, before each upgrade of `kcm` to a new version,
+a new backup will be created.
+
+Automatically created backups have the
+following name template to make it easier to find them:
+the name of the `ManagementBackup` object with enabled `performOnManagementUpgrade`
+concatenates with the name of the release before the upgrade,
+e.g. `example-backup-kcm-0-1-0`.
+
+Automatically created backups have the following label
+`k0rdent.mirantis.com/release-backup`
+with the name of the release before the upgrade as its value
+to simplify querying if required.
+
+### Rollback
+
+If during the `kcm` upgrade a failure happens, a rollback operation
+should be performed to restore the `kcm` to its before-the-upgrade state:
+
+1. Follow the first 2 steps from the [restoration section](#general-case),
+   creating a clean `kcm` installation and `BackupStorageLocation`/`Secret`.
+
+1. > WARNING:
+   > Please consider the [restoration caveats](#caveats) section before proceeding.
+
+    Create the `ConfigMap` object with patches to revert the `Management`
+    `.spec.release`, substitute the `<version-before-upgrade>` with
+    the version of `kcm` before the upgrade, and create the `Restore` object
+    propagating the `ConfigMap` to it:
+
+     ```yaml
+     ---
+     apiVersion: v1
+     data:
+       patch-mgmt-spec-release: |
+         version: v1
+         resourceModifierRules:
+         - conditions:
+             groupResource: managements.k0rdent.mirantis.com
+           patches:
+           - operation: replace
+             path: "/spec/release"
+             value: "<version-before-upgrade>"
+     kind: ConfigMap
+     metadata:
+       name: patch-mgmt-spec-release
+       namespace: kcm-system
+     ---
+     apiVersion: velero.io/v1
+     kind: Restore
+     metadata:
+       name: <restore-name>
+       namespace: kcm-system
+     spec:
+       backupName: <backup-name>
+       existingResourcePolicy: update
+       includedNamespaces:
+       - '*'
+       resourceModifier: # propagate patches
+         kind: ConfigMap
+         name: patch-mgmt-spec-release
+     ```
+
+1. Wait until the `Restore` status is `Completed` and all `kcm` components are up and running.
+1. Optionally delete the created `ConfigMap`.
 
 ## Caveats / Limitation
 
 <!-- TODO: not sure whether it is okay to mention that explicitly since we could implement
 it somewhere in the future utilizing velero hooks -->
 
+The credentials stored in backups might and will stale,
+so a proper rotation should be considered beforehand.
+
 All `velero` caveats and limitations are transitively implied in the `k0rdent`.
 
 In particular, that means no backup encryption is provided until it is implemented
-by a `velero` plugin that supports both encryption and cloud storage backups.
+by a `velero` plugin that supports encryption and cloud storage backups.
+
+## Velero Backups / Restores deletion
+
+### Delete Restores
+
+To delete `velero` `Restore` from the management cluster
+**and** from the cloud storage, delete `restores.velero.io` object(s),
+e.g. with the following command:
+
+```bash
+kubectl delete restores.velero.io -n kcm-system <restore-name>
+```
+
+> WARNING:
+> Deletion of a `Restore` object deletes it from both
+> the management cluster and from the cloud storage.
+
+### Delete Backups
+
+To remove `velero` `Backup` from the management cluster,
+delete `backups.velero.io` object(s), e.g. with the following command:
+
+```bash
+kubectl delete backups.velero.io -n kcm-system <velero-backup-name>
+```
+
+> HINT:
+> The command above only removes objects from
+> the cluster, the data continues to persist
+> on the cloud storage.
+>
+> The deleted object will be recreated in the
+> cluster if its `BackupStorageLocation` `.spec.backupSyncPeriod`
+> is set and does not equal `0`.
+
+To delete `velero` `Backup` from the management cluster
+**and** from the cloud storage, create the following `DeleteBackupRequest` object:
+
+```yaml
+apiVersion: velero.io/v1
+kind: DeleteBackupRequest
+metadata:
+  name: delete-backup-completely
+  namespace: kcm-system
+spec:
+  backupName: <velero-backup>
+```
+
+> WARNING:
+> Deletion of a `Backup` object via the `DeleteBackupRequest`
+> deletes it from both
+> the management cluster and from the cloud storage.
+
+Optionally, delete the created `DeleteBackupRequest` object
+from the cluster after `Backup` has been deleted.
+
+For reference, follow the [official documentation](https://velero.io/docs/v1.15/backup-reference/#deleting-backups).

--- a/docs/usage/adopt-existing-cluster.md
+++ b/docs/usage/adopt-existing-cluster.md
@@ -10,8 +10,8 @@ In order to adopt an existing Kubernetes cluster you will require the following:
 
 ## Installation
 
-
 ### Step 1: Create the credential
+
 Create a `Credential` object with all credentials required per the
   [Credential System](../credential/main.md).
 
@@ -42,11 +42,11 @@ Create a `Credential` object with all credentials required per the
 >
 > Substitute the parameters enclosed in angle brackets with the corresponding
 > values. Enable the `dryRun` flag if required. For details, see
-> [Dry Run](#dry-run).
+> [Dry Run](create-cluster-deployment.md#dry-run).
 
 Following is an interpolated example.
 
-> EXAMPLE: `ClusterDeployment` 
+> EXAMPLE: `ClusterDeployment`
 >
 > ```yaml
 > apiVersion: k0rdent.mirantis.com/v1alpha1
@@ -60,7 +60,6 @@ Following is an interpolated example.
 >   dryRun: true
 >   config: {}
 > ```
-
 
 ### Step 4: Apply the `ClusterDeployment` Configuration to Create it
 


### PR DESCRIPTION
* added upgrade/rollback
* added more detailed examples
* added info on adding a plugin beforehand
* added caveats during restoration
* added delete restore/backup section
* put more emphasis on backing the management cluster
* updated refs accordingly to the new ones
* fixed a ref miss in the adopt-existing-cluster.md

Closes https://github.com/k0rdent/kcm/issues/948